### PR TITLE
Secret Sharing in RSA

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,18 +7,19 @@ verify_ssl = true
 black = "*"
 coverage = "*"
 docutils = "*"
+hypothesis = "==5.15.1"
 mkdocs = "*"
 mypy = "*"
 pydeps = "*"
 pydocstyle = "*"
 pylint = "*"
 pytest = "*"
+typish = '*'
 
 [packages]
-hypothesis = "==5.15.1"
 numpy = '==1.18.2'
 jsons = '==1.1.2'
-typish = '*'
+cryptography = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0394e8b025ac3133bdccb00437b62c42cdff13febb51b748791f1beee576313f"
+            "sha256": "ad22e64b7a515256ed40b2a0660ac4fdf9e157e461e1833a1d92f48c64c1845d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,20 +16,63 @@
         ]
     },
     "default": {
-        "attrs": {
+        "cffi": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==19.3.0"
+            "version": "==1.14.0"
         },
-        "hypothesis": {
+        "cryptography": {
             "hashes": [
-                "sha256:d44142b80572bb3392dd018a6b2e59f54b2ba77da50e2dd0cbddd815b7a84005",
-                "sha256:f523846f1e323e5d74694a437ef9f681ac1643e45404dc5c5bb7d1ee947c4a99"
+                "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
+                "sha256:18452582a3c85b96014b45686af264563e3e5d99d226589f057ace56196ec78b",
+                "sha256:1dfa985f62b137909496e7fc182dac687206d8d089dd03eaeb28ae16eec8e7d5",
+                "sha256:1e4014639d3d73fbc5ceff206049c5a9a849cefd106a49fa7aaaa25cc0ce35cf",
+                "sha256:22e91636a51170df0ae4dcbd250d318fd28c9f491c4e50b625a49964b24fe46e",
+                "sha256:3b3eba865ea2754738616f87292b7f29448aec342a7c720956f8083d252bf28b",
+                "sha256:651448cd2e3a6bc2bb76c3663785133c40d5e1a8c1a9c5429e4354201c6024ae",
+                "sha256:726086c17f94747cedbee6efa77e99ae170caebeb1116353c6cf0ab67ea6829b",
+                "sha256:844a76bc04472e5135b909da6aed84360f522ff5dfa47f93e3dd2a0b84a89fa0",
+                "sha256:88c881dd5a147e08d1bdcf2315c04972381d026cdb803325c03fe2b4a8ed858b",
+                "sha256:96c080ae7118c10fcbe6229ab43eb8b090fccd31a09ef55f83f690d1ef619a1d",
+                "sha256:a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229",
+                "sha256:bb1f0281887d89617b4c68e8db9a2c42b9efebf2702a3c5bf70599421a8623e3",
+                "sha256:c447cf087cf2dbddc1add6987bbe2f767ed5317adb2d08af940db517dd704365",
+                "sha256:c4fd17d92e9d55b84707f4fd09992081ba872d1a0c610c109c18e062e06a2e55",
+                "sha256:d0d5aeaedd29be304848f1c5059074a740fa9f6f26b84c5b63e8b29e73dfc270",
+                "sha256:daf54a4b07d67ad437ff239c8a4080cfd1cc7213df57d33c97de7b4738048d5e",
+                "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
+                "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
             ],
             "index": "pypi",
-            "version": "==5.15.1"
+            "version": "==2.9.2"
         },
         "jsons": {
             "hashes": [
@@ -65,18 +108,24 @@
             "index": "pypi",
             "version": "==1.18.2"
         },
-        "sortedcontainers": {
+        "pycparser": {
             "hashes": [
-                "sha256:4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba",
-                "sha256:c633ebde8580f241f274c1f8994a665c0e54a17724fecd0cae2f079e09c36d3f"
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
-            "version": "==2.2.2"
+            "version": "==2.20"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
         },
         "typish": {
             "hashes": [
                 "sha256:c97c6fa33e86daab4bde63e8f81deb07c48e1023d588599a3a74e45e15fff811"
             ],
-            "index": "pypi",
             "version": "==1.7.0"
         }
     },
@@ -119,40 +168,43 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
-                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
-                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
-                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
-                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
-                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
-                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
-                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
-                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
-                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
-                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
-                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
-                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
-                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
-                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
-                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
-                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
-                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
-                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
-                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
-                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
-                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
-                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
-                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
-                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
-                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
-                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
-                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
-                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
-                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
-                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+                "sha256:0fc4e0d91350d6f43ef6a61f64a48e917637e1dcfcba4b4b7d543c628ef82c2d",
+                "sha256:10f2a618a6e75adf64329f828a6a5b40244c1c50f5ef4ce4109e904e69c71bd2",
+                "sha256:12eaccd86d9a373aea59869bc9cfa0ab6ba8b1477752110cb4c10d165474f703",
+                "sha256:1874bdc943654ba46d28f179c1846f5710eda3aeb265ff029e0ac2b52daae404",
+                "sha256:1dcebae667b73fd4aa69237e6afb39abc2f27520f2358590c1b13dd90e32abe7",
+                "sha256:1e58fca3d9ec1a423f1b7f2aa34af4f733cbfa9020c8fe39ca451b6071237405",
+                "sha256:214eb2110217f2636a9329bc766507ab71a3a06a8ea30cdeebb47c24dce5972d",
+                "sha256:25fe74b5b2f1b4abb11e103bb7984daca8f8292683957d0738cd692f6a7cc64c",
+                "sha256:32ecee61a43be509b91a526819717d5e5650e009a8d5eda8631a59c721d5f3b6",
+                "sha256:3740b796015b889e46c260ff18b84683fa2e30f0f75a171fb10d2bf9fb91fc70",
+                "sha256:3b2c34690f613525672697910894b60d15800ac7e779fbd0fccf532486c1ba40",
+                "sha256:41d88736c42f4a22c494c32cc48a05828236e37c991bd9760f8923415e3169e4",
+                "sha256:42fa45a29f1059eda4d3c7b509589cc0343cd6bbf083d6118216830cd1a51613",
+                "sha256:4bb385a747e6ae8a65290b3df60d6c8a692a5599dc66c9fa3520e667886f2e10",
+                "sha256:509294f3e76d3f26b35083973fbc952e01e1727656d979b11182f273f08aa80b",
+                "sha256:5c74c5b6045969b07c9fb36b665c9cac84d6c174a809fc1b21bdc06c7836d9a0",
+                "sha256:60a3d36297b65c7f78329b80120f72947140f45b5c7a017ea730f9112b40f2ec",
+                "sha256:6f91b4492c5cde83bfe462f5b2b997cdf96a138f7c58b1140f05de5751623cf1",
+                "sha256:7403675df5e27745571aba1c957c7da2dacb537c21e14007ec3a417bf31f7f3d",
+                "sha256:87bdc8135b8ee739840eee19b184804e5d57f518578ffc797f5afa2c3c297913",
+                "sha256:8a3decd12e7934d0254939e2bf434bf04a5890c5bf91a982685021786a08087e",
+                "sha256:9702e2cb1c6dec01fb8e1a64c015817c0800a6eca287552c47a5ee0ebddccf62",
+                "sha256:a4d511012beb967a39580ba7d2549edf1e6865a33e5fe51e4dce550522b3ac0e",
+                "sha256:bbb387811f7a18bdc61a2ea3d102be0c7e239b0db9c83be7bfa50f095db5b92a",
+                "sha256:bfcc811883699ed49afc58b1ed9f80428a18eb9166422bce3c31a53dba00fd1d",
+                "sha256:c32aa13cc3fe86b0f744dfe35a7f879ee33ac0a560684fef0f3e1580352b818f",
+                "sha256:ca63dae130a2e788f2b249200f01d7fa240f24da0596501d387a50e57aa7075e",
+                "sha256:d54d7ea74cc00482a2410d63bf10aa34ebe1c49ac50779652106c867f9986d6b",
+                "sha256:d67599521dff98ec8c34cd9652cbcfe16ed076a2209625fca9dc7419b6370e5c",
+                "sha256:d82db1b9a92cb5c67661ca6616bdca6ff931deceebb98eecbd328812dab52032",
+                "sha256:d9ad0a988ae20face62520785ec3595a5e64f35a21762a57d115dae0b8fb894a",
+                "sha256:ebf2431b2d457ae5217f3a1179533c456f3272ded16f8ed0b32961a6d90e38ee",
+                "sha256:ed9a21502e9223f563e071759f769c3d6a2e1ba5328c31e86830368e8d78bc9c",
+                "sha256:f50632ef2d749f541ca8e6c07c9928a37f87505ce3a9f20c8446ad310f1aa87b"
             ],
             "index": "pypi",
-            "version": "==5.1"
+            "version": "==5.2"
         },
         "docutils": {
             "hashes": [
@@ -167,6 +219,20 @@
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
             "version": "==0.18.2"
+        },
+        "hypothesis": {
+            "hashes": [
+                "sha256:d44142b80572bb3392dd018a6b2e59f54b2ba77da50e2dd0cbddd815b7a84005",
+                "sha256:f523846f1e323e5d74694a437ef9f681ac1643e45404dc5c5bb7d1ee947c4a99"
+            ],
+            "index": "pypi",
+            "version": "==5.15.1"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:aa0b40f50a00e72323cb5d41302f9c6165728fd764ac8822aa3fff00a40d56b4"
+            ],
+            "version": "==1.0.0"
         },
         "isort": {
             "hashes": [
@@ -184,10 +250,10 @@
         },
         "joblib": {
             "hashes": [
-                "sha256:61e49189c84b3c5d99a969d314853f4d1d263316cc694bec17548ebaa9c47b6e",
-                "sha256:6825784ffda353cc8a1be573118085789e5b5d29401856b35b756645ab5aecb5"
+                "sha256:8f52bf24c64b608bf0b2563e0e47d6fcf516abc8cfafe10cfd98ad66d94f92d6",
+                "sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49"
             ],
-            "version": "==0.15.1"
+            "version": "==0.16.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -343,10 +409,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44",
-                "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "version": "==1.8.2"
+            "version": "==1.9.0"
         },
         "pydeps": {
             "hashes": [
@@ -374,18 +440,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2",
+                "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce"
             ],
-            "version": "==3.0.0a1"
+            "version": "==3.0.0a2"
         },
         "pytest": {
             "hashes": [
-                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
-                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
+                "sha256:3296b4ad0b07363f69b740edf70e40db8286f882f019179b31e6a03d896afbff",
+                "sha256:c934e33079966229fd236ffae6a7a3c3415bd585693a646ba3adb62a2d695874"
             ],
             "index": "pypi",
-            "version": "==5.4.3"
+            "version": "==6.0.0rc1"
         },
         "pyyaml": {
             "hashes": [
@@ -443,6 +509,13 @@
             ],
             "version": "==2.0.0"
         },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba",
+                "sha256:c633ebde8580f241f274c1f8994a665c0e54a17724fecd0cae2f079e09c36d3f"
+            ],
+            "version": "==2.2.2"
+        },
         "stdlib-list": {
             "hashes": [
                 "sha256:0ed79a0badf4f666aad046cde364ccac68ca1438a211ec74b0153e0eb5642a3e",
@@ -473,10 +546,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:07c06493f1403c1380b630ae3dcbe5ae62abcf369a93bbc052502279f189ab8c",
-                "sha256:cd140979c2bebd2311dfb14781d8f19bd5a9debb92dcab9f6ef899c987fcf71f"
+                "sha256:63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7",
+                "sha256:7810e627bcf9d983a99d9ff8a0c09674400fd2927eddabeadf153c14a2ec8656"
             ],
-            "version": "==4.46.1"
+            "version": "==4.47.0"
         },
         "typed-ast": {
             "hashes": [
@@ -512,12 +585,11 @@
             ],
             "version": "==3.7.4.2"
         },
-        "wcwidth": {
+        "typish": {
             "hashes": [
-                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+                "sha256:c97c6fa33e86daab4bde63e8f81deb07c48e1023d588599a3a74e45e15fff811"
             ],
-            "version": "==0.2.5"
+            "version": "==1.7.0"
         },
         "wrapt": {
             "hashes": [

--- a/docs/1_Key_Ceremony.md
+++ b/docs/1_Key_Ceremony.md
@@ -34,26 +34,29 @@ This is a detailed description of the entire Key Ceremony Process
 
 1. The ceremony details are decided upon. These include a `number_of_guardians` and `quorum` of guardians required for decryption.
 2. Each guardian creates a unique `id` and `sequence_order`.
-3. Each guardian must generate their `auxiliary key pair`.
+3. Each guardian must generate their `auxiliary key pair`.\*
 4. Each guardian must give the other guardians their `auxiliary public key` directly or through a mediator.
 5. Each guardian must check if all `auxiliary public keys` are received.
 6. Each guardian must generate their `election key pair` _(ElGamal key pair)_. This will generate a corresponding Schnorr `proof` and `polynomial` used for generating `election partial key backups` for sharing.
 7. Each guardian must give the other guardians their `election public key` directly or through a mediator.
 8. Each guardian must check if all `election public keys` are received.
-9. Each guardian must generate `election partial key backup` for each other guardian. The guardian will use their `polynomial` and the designated guardian's `sequence_order` to create the value. The backup will be encrypted with the designated guardian's `auxiliary public key`
+9. Each guardian must generate `election partial key backup` for each other guardian. The guardian will use their `polynomial` and the designated guardian's `sequence_order` to create the value. The backup will be encrypted with the designated guardian's `auxiliary public key`\*
 10. Each guardian must send each encrypted `election partial key backup` to the designated guardian directly or through a `mediator`.
 11. Each guardian checks if all encrypted `election partial key backups` have been received by their recipient guardian directly or through a mediator.
-12. Each recipient guardian decrypts each received encrypted `election partial key backup` with their own `auxiliary private key`
+12. Each recipient guardian decrypts each received encrypted `election partial key backup` with their own `auxiliary private key`\*
 13. Each recipient guardian verifies each `election partial key backup` and sends confirmation of verification
     - If the proof verifies, continue
     - If the proof fails
-      1. Sender guardian publishes the `election partial key backup` value sent to recipient as a `election partial key challenge` where the value is **unencrypted** to all the other guardians \*
+      1. Sender guardian publishes the `election partial key backup` value sent to recipient as a `election partial key challenge` where the value is **unencrypted** to all the other guardians \*\*
       2. Alternate guardian (outside sender or original recipient) attempts to verify key
          - If the proof verifies, continue
          - If the proof fails again, the accused (sender guardian) should be evicted and process should be restarted with new guardian.
 14. On receipt of all verifications of `election partial private keys` by all guardians, generate and publish `joint key` from election public keys
 
-\* **Note:** _The confidentiality of this value is now gone, but since the two Guardians are in the dispute, at least one is misbehaving and could be revealing this data._
+
+\* **Note:** _The auxiliary encrypt and decrypt functions can be overridden to allow different encryption mechanisms other than the default._
+
+\*\* **Note:** _The confidentiality of this value is now gone, but since the two Guardians are in the dispute, at least one is misbehaving and could be revealing this data._
 
 ## Files
 

--- a/src/electionguard/auxiliary.py
+++ b/src/electionguard/auxiliary.py
@@ -1,0 +1,43 @@
+from typing import Callable, Optional, NamedTuple
+
+from .types import GUARDIAN_ID
+
+MESSAGE = str
+PUBLIC_KEY = str
+SECRET_KEY = str
+ENCRYPTED_MESSAGE = str
+
+
+class AuxiliaryKeyPair(NamedTuple):
+    """A tuple of a secret key and public key."""
+
+    secret_key: SECRET_KEY
+    """The secret or private key"""
+    public_key: PUBLIC_KEY
+
+
+class AuxiliaryPublicKey(NamedTuple):
+    """A tuple of auxiliary public key and owner information"""
+
+    owner_id: GUARDIAN_ID
+    """
+    The unique identifier of the guardian
+    """
+
+    sequence_order: int
+    """
+    The sequence order of the auxiliary public key (usually the guardian's sequence order)
+    """
+
+    key: PUBLIC_KEY
+    """
+    A string representation of the Auxiliary public key.  
+    It is up to the external `AuxiliaryEncrypt` function to know how to parse this value
+    """
+
+
+AuxiliaryEncrypt = Callable[[MESSAGE, PUBLIC_KEY], Optional[ENCRYPTED_MESSAGE]]
+"""A callable type that represents the auxiliary encryption scheme."""
+
+AuxiliaryDecrypt = Callable[[ENCRYPTED_MESSAGE, SECRET_KEY], Optional[MESSAGE]]
+"""A callable type that represents the auxiliary decryption scheme."""

--- a/src/electionguard/rsa.py
+++ b/src/electionguard/rsa.py
@@ -1,0 +1,108 @@
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    generate_private_key,
+    RSAPrivateKey,
+    RSAPrivateKeyWithSerialization,
+    RSAPublicKey,
+)
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    load_pem_private_key,
+    load_pem_public_key,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+from typing import Optional, NamedTuple
+
+
+PUBLIC_EXPONENT = 65537
+KEY_SIZE = 4096
+PADDING = 11
+MAX_BITS = int(KEY_SIZE / 8) - PADDING
+ISO_ENCODING = "ISO-8859-1"
+BYTE_ORDER = "big"
+
+
+class RSAKeyPair(NamedTuple):
+    """Key pair of RSA pkcs1 in bytes"""
+
+    private_key: str
+    public_key: str
+
+
+def rsa_keypair() -> RSAKeyPair:
+    """
+    Create RSA keypair
+
+    :return: RSA key pair
+    """
+
+    private_key: RSAPrivateKeyWithSerialization = generate_private_key(
+        public_exponent=PUBLIC_EXPONENT, key_size=KEY_SIZE, backend=default_backend()
+    )
+    private_key_bytes = private_key.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=NoEncryption(),
+    )
+    private_key_string = str(private_key_bytes, ISO_ENCODING)
+
+    public_key: RSAPublicKey = private_key.public_key()
+    public_key_bytes = public_key.public_bytes(
+        encoding=Encoding.PEM, format=PublicFormat.SubjectPublicKeyInfo
+    )
+    public_key_string = str(public_key_bytes, ISO_ENCODING)
+
+    return RSAKeyPair(private_key_string, public_key_string)
+
+
+def rsa_encrypt(message: str, public_key: str) -> Optional[str]:
+    """
+    Encrypt with RSA public key
+
+    :param message: Message
+    :param key_pair: RSA public key
+    :return: Encrypted message
+    """
+    data = bytes(public_key, ISO_ENCODING)
+    rsa_public_key: RSAPublicKey = load_pem_public_key(data, backend=default_backend())
+    integer = int(message)
+    bits = count_set_bits(integer)
+    if bits > MAX_BITS:
+        return None
+    plaintext = integer.to_bytes(bits, BYTE_ORDER)
+    ciphertext = rsa_public_key.encrypt(plaintext, PKCS1v15())
+    return str(ciphertext, ISO_ENCODING)
+
+
+def rsa_decrypt(encrypted_message: str, private_key: str) -> Optional[str]:
+    """
+    Decrypt with RSA private key
+
+    :param encrypted_message: Encrypted message
+    :param private_key: RSA private key
+    :return: Message
+    """
+
+    data = bytes(private_key, ISO_ENCODING)
+    rsa_private_key: RSAPrivateKey = load_pem_private_key(
+        data, password=None, backend=default_backend()
+    )
+    ciphertext = bytes(encrypted_message, ISO_ENCODING)
+    try:
+        plaintext = rsa_private_key.decrypt(ciphertext, PKCS1v15())
+    except ValueError:
+        return None
+    integer = int.from_bytes(plaintext, BYTE_ORDER)
+    return str(integer)
+
+
+def count_set_bits(n: int) -> int:
+    """Count set bits for a particular integer"""
+    count = 0
+    while n:
+        count += n & 1
+        n >>= 1
+    return count

--- a/tests/test_decryption_mediator.py
+++ b/tests/test_decryption_mediator.py
@@ -205,6 +205,9 @@ class TestDecryptionMediator(TestCase):
         # Cannot get plaintext tally without a quorum
         self.assertIsNone(subject.get_plaintext_tally())
 
+    def tearDown(self):
+        self.key_ceremony.reset(CeremonyDetails(self.NUMBER_OF_GUARDIANS, self.QUORUM))
+
     def test_compute_selection(self):
         # Arrange
         first_selection = [

--- a/tests/test_key_ceremony.py
+++ b/tests/test_key_ceremony.py
@@ -4,8 +4,8 @@ from electionguard.data_store import DataStore
 from electionguard.key_ceremony import (
     AuxiliaryPublicKey,
     ElectionPublicKey,
-    generate_elgamal_auxiliary_key_pair,
     generate_election_key_pair,
+    generate_rsa_auxiliary_key_pair,
     generate_election_partial_key_backup,
     verify_election_partial_key_backup,
     generate_election_partial_key_challenge,
@@ -19,16 +19,15 @@ RECIPIENT_GUARDIAN_ID = "Test Guardian 2"
 ALTERNATE_VERIFIER_GUARDIAN_ID = "Test Guardian 3"
 SENDER_SEQUENCE_ORDER = 1
 RECIPIENT_SEQUENCE_ORDER = 2
-AUXILIARY_PUBLIC_KEY = "Test Public Key"
 NUMBER_OF_GUARDIANS = 5
 QUORUM = 3
 
 
 class TestKeyCeremony(TestCase):
-    def test_generate_elgamal_auxiliary_key_pair(self):
+    def test_generate_rsa_auxiliary_key_pair(self):
 
         # Act
-        auxiliary_key_pair = generate_elgamal_auxiliary_key_pair()
+        auxiliary_key_pair = generate_rsa_auxiliary_key_pair()
 
         # Assert
         self.assertIsNotNone(auxiliary_key_pair)
@@ -51,8 +50,11 @@ class TestKeyCeremony(TestCase):
     def test_generate_election_partial_key_backup(self):
         # Arrange
         election_key_pair = generate_election_key_pair(QUORUM)
+        auxiliary_key_pair = generate_rsa_auxiliary_key_pair()
         auxiliary_public_key = AuxiliaryPublicKey(
-            RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, AUXILIARY_PUBLIC_KEY
+            RECIPIENT_GUARDIAN_ID,
+            RECIPIENT_SEQUENCE_ORDER,
+            auxiliary_key_pair.public_key,
         )
 
         # Act
@@ -72,7 +74,7 @@ class TestKeyCeremony(TestCase):
 
     def test_verify_election_partial_key_backup(self):
         # Arrange
-        recipient_auxiliary_key_pair = generate_elgamal_auxiliary_key_pair()
+        recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair()
         sender_election_key_pair = generate_election_key_pair(QUORUM)
         recipient_auxiliary_public_key = AuxiliaryPublicKey(
             RECIPIENT_GUARDIAN_ID,
@@ -99,7 +101,7 @@ class TestKeyCeremony(TestCase):
 
     def test_generate_election_partial_key_challenge(self):
         # Arrange
-        recipient_auxiliary_key_pair = generate_elgamal_auxiliary_key_pair()
+        recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair()
         sender_election_key_pair = generate_election_key_pair(QUORUM)
         recipient_auxiliary_public_key = AuxiliaryPublicKey(
             RECIPIENT_GUARDIAN_ID,
@@ -129,7 +131,7 @@ class TestKeyCeremony(TestCase):
 
     def test_verify_election_partial_key_challenge(self):
         # Arrange
-        recipient_auxiliary_key_pair = generate_elgamal_auxiliary_key_pair()
+        recipient_auxiliary_key_pair = generate_rsa_auxiliary_key_pair()
         sender_election_key_pair = generate_election_key_pair(QUORUM)
         recipient_auxiliary_public_key = AuxiliaryPublicKey(
             RECIPIENT_GUARDIAN_ID,

--- a/tests/test_rsa.py
+++ b/tests/test_rsa.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from electionguard.rsa import rsa_decrypt, rsa_encrypt, rsa_keypair
+
+
+class TestRSA(TestCase):
+    def test_rsa_encrypt(self) -> None:
+        # Arrange
+        message = "1118632206964768372384343373859700232583178373031391293942056347262996938448167273037401292830794700541756937515976417908858473208686448118280677278101719098670646913045584007219899471676906742553167177135624664615778816843133781654175330682468454244343379"
+
+        # Act
+        key_pair = rsa_keypair()
+        encrypted_message = rsa_encrypt(message, key_pair.public_key)
+        decrypted_message = rsa_decrypt(encrypted_message, key_pair.private_key)
+
+        # Assert
+        self.assertIsNotNone(key_pair)
+        self.assertGreater(len(key_pair.private_key), 0)
+        self.assertGreater(len(key_pair.public_key), 0)
+
+        self.assertIsNotNone(encrypted_message)
+        self.assertIsNotNone(decrypted_message)
+
+        self.assertEqual(message, decrypted_message)


### PR DESCRIPTION
### Issue

Fixes #99  

### Description
Add RSA encryption as default method to messages between guardians for sharing of the secrets. PR originally encompassed other cards hence the branch name is a bit off. There was also a bug discovered with the test_decryption_mediator.

### Testing
* test_rsa.py

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!