### PR TITLE
added check to suppress unnecessary log warning

### DIFF
--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -626,14 +626,6 @@ class CiphertextBallot(ElectionObjectBase, CryptoHashCheckable):
         :return: a hash value derived from the description hash, the object id, and the nonce value
                 suitable for deriving other nonce values on the ballot
         """
-
-        if self.nonce is None:
-            if not isinstance(self, CiphertextAcceptedBallot):
-                log_warning(
-                    f"missing nonce for ballot {self.object_id} could not derive from null nonce"
-                )
-            return None
-
         return hash_elems(self.description_hash, self.object_id, self.nonce)
 
     def generate_tracking_id(self, seed_hash: ElementModQ) -> None:

--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -628,9 +628,10 @@ class CiphertextBallot(ElectionObjectBase, CryptoHashCheckable):
         """
 
         if self.nonce is None:
-            log_warning(
-                f"missing nonce for ballot {self.object_id} could not derive from null nonce"
-            )
+            if not isinstance(self, CiphertextAcceptedBallot):
+                log_warning(
+                    f"missing nonce for ballot {self.object_id} could not derive from null nonce"
+                )
             return None
 
         return hash_elems(self.description_hash, self.object_id, self.nonce)

--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass, field, InitVar
+from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from distutils import util
+from enum import Enum
 from typing import Optional, List, Any, Sequence
 
 from .chaum_pedersen import (
@@ -16,7 +16,7 @@ from .group import add_q, ElementModP, ElementModQ, ZERO_MOD_Q
 from .hash import CryptoHashCheckable, hash_elems
 from .logs import log_warning
 from .tracker import get_rotating_tracker_hash, tracker_hash_to_words
-from .utils import to_ticks
+from .utils import to_ticks, flatmap_optional
 
 
 def _list_eq(
@@ -168,11 +168,8 @@ class CiphertextBallotSelection(ElectionObjectBase, CryptoHashCheckable):
     # The encrypted representation of the plaintext field
     message: ElGamalCiphertext
 
-    elgamal_public_key: InitVar[ElementModP]
-
-    proof_seed: InitVar[ElementModQ]
-
-    selection_representation: InitVar[int]
+    # The hash of the encrypted values
+    crypto_hash: ElementModQ
 
     # determines if this is a placeholder selection
     is_placeholder_selection: bool = field(default=False)
@@ -181,41 +178,15 @@ class CiphertextBallotSelection(ElectionObjectBase, CryptoHashCheckable):
     # this value is sensitive & should be treated as a secret
     nonce: Optional[ElementModQ] = field(default=None)
 
-    # The hash of the encrypted values
-    crypto_hash: ElementModQ = field(init=False)
-
     # the proof that demonstrates the selection is an encryption of 0 or 1,
     # and was encrypted using the `nonce`
-    proof: Optional[DisjunctiveChaumPedersenProof] = field(init=False, default=None)
+    proof: Optional[DisjunctiveChaumPedersenProof] = field(default=None)
 
     # TODO: ISSUE #35: encrypt/decrypt
     extended_data: Optional[ElGamalCiphertext] = field(default=None)
     """
     encrypted representation of the extended_data field
     """
-
-    def __post_init__(
-        self,
-        elgamal_public_key: ElementModP,
-        proof_seed: ElementModQ,
-        selection_representation: int,
-    ) -> None:
-        object.__setattr__(
-            self, "crypto_hash", self.crypto_hash_with(self.description_hash)
-        )
-
-        if self.nonce is not None:
-            object.__setattr__(
-                self,
-                "proof",
-                make_disjunctive_chaum_pedersen(
-                    self.message,
-                    self.nonce,
-                    elgamal_public_key,
-                    proof_seed,
-                    selection_representation,
-                ),
-            )
 
     def is_valid_encryption(
         self, seed_hash: ElementModQ, elgamal_public_key: ElementModP
@@ -261,8 +232,59 @@ class CiphertextBallotSelection(ElectionObjectBase, CryptoHashCheckable):
 
         In most cases the seed_hash should match the `description_hash`
         """
+        return _ciphertext_ballot_selection_crypto_hash_with(
+            self.object_id, seed_hash, self.message
+        )
 
-        return hash_elems(self.object_id, seed_hash, self.message.crypto_hash())
+
+def _ciphertext_ballot_selection_crypto_hash_with(
+    object_id: str, seed_hash: ElementModQ, message: ElGamalCiphertext
+) -> ElementModQ:
+    return hash_elems(object_id, seed_hash, message.crypto_hash())
+
+
+def make_ciphertext_ballot_selection(
+    object_id: str,
+    description_hash: ElementModQ,
+    message: ElGamalCiphertext,
+    elgamal_public_key: ElementModP,
+    proof_seed: ElementModQ,
+    selection_representation: int,
+    is_placeholder_selection: bool = False,
+    nonce: Optional[ElementModQ] = None,
+    crypto_hash: Optional[ElementModQ] = None,
+    proof: Optional[DisjunctiveChaumPedersenProof] = None,
+    extended_data: Optional[ElGamalCiphertext] = None,
+) -> CiphertextBallotSelection:
+    """
+    Constructs a `CipherTextBallotSelection` object. Most of the parameters here match up to fields
+    in the class, but this helper function will optionally compute a Chaum-Pedersen proof if the
+    given nonce isn't `None`. Likewise, if a crypto_hash is not provided, it will be derived from
+    the other fields.
+    """
+    if crypto_hash is None:
+        crypto_hash = _ciphertext_ballot_selection_crypto_hash_with(
+            object_id, description_hash, message
+        )
+
+    if proof is None:
+        proof = flatmap_optional(
+            nonce,
+            lambda n: make_disjunctive_chaum_pedersen(
+                message, n, elgamal_public_key, proof_seed, selection_representation
+            ),
+        )
+
+    return CiphertextBallotSelection(
+        object_id=object_id,
+        description_hash=description_hash,
+        message=message,
+        is_placeholder_selection=is_placeholder_selection,
+        nonce=nonce,
+        crypto_hash=crypto_hash,
+        proof=proof,
+        extended_data=extended_data,
+    )
 
 
 @dataclass
@@ -364,64 +386,24 @@ class CiphertextBallotContest(ElectionObjectBase, CryptoHashCheckable):
     # collection of ballot selections
     ballot_selections: List[CiphertextBallotSelection]
 
-    elgamal_public_key: InitVar[ElementModP]
-
-    proof_seed: InitVar[ElementModQ]
-
-    number_elected: InitVar[int]
+    # Hash of the encrypted values
+    crypto_hash: ElementModQ
 
     # the nonce used to generate the encryption
     # this value is sensitive & should be treated as a secret
-    nonce: Optional[ElementModQ] = field(default=None)
-
-    # Hash of the encrypted values
-    crypto_hash: ElementModQ = field(init=False)
+    nonce: Optional[ElementModQ] = None
 
     # the proof demonstrates the sum of the selections does not exceed the maximum
     # available selections for the contest, and that the proof was generated with the nonce
-    proof: Optional[ConstantChaumPedersenProof] = field(init=False)
-
-    def __post_init__(
-        self,
-        elgamal_public_key: ElementModP,
-        proof_seed: ElementModQ,
-        number_elected: int,
-    ) -> None:
-        object.__setattr__(
-            self, "crypto_hash", self.crypto_hash_with(self.description_hash)
-        )
-
-        aggregate = self.aggregate_nonce()
-
-        if aggregate is not None:
-            # Generate the proof when the object is created
-            object.__setattr__(
-                self,
-                "proof",
-                make_constant_chaum_pedersen(
-                    message=self.elgamal_accumulate(),
-                    constant=number_elected,
-                    r=aggregate,
-                    k=elgamal_public_key,
-                    seed=proof_seed,
-                ),
-            )
+    proof: Optional[ConstantChaumPedersenProof] = None
 
     def aggregate_nonce(self) -> Optional[ElementModQ]:
         """
         :return: an aggregate nonce for the contest composed of the nonces of the selections
         """
-        selection_nonces: List[ElementModQ] = list()
-        for selection in self.ballot_selections:
-            if selection.nonce is None:
-                log_warning(
-                    f"missing nonce values for contest {self.object_id} cannot calculate aggregate nonce"
-                )
-                return None
-            else:
-                selection_nonces.append(selection.nonce)
-
-        return add_q(*selection_nonces)
+        return _ciphertext_ballot_contest_aggregate_nonce(
+            self.object_id, self.ballot_selections
+        )
 
     def crypto_hash_with(self, seed_hash: ElementModQ) -> ElementModQ:
         """
@@ -434,25 +416,16 @@ class CiphertextBallotContest(ElectionObjectBase, CryptoHashCheckable):
 
         In most cases, the seed_hash is the description_hash
         """
-
-        if len(self.ballot_selections) == 0:
-            log_warning(
-                f"mismatching ballot_selections state: {self.object_id} expected(some), actual(none)"
-            )
-            return ZERO_MOD_Q
-
-        selection_hashes = [
-            selection.crypto_hash for selection in self.ballot_selections
-        ]
-
-        return hash_elems(self.object_id, seed_hash, *selection_hashes)
+        return _ciphertext_ballot_context_crypto_hash(
+            self.object_id, self.ballot_selections, seed_hash
+        )
 
     def elgamal_accumulate(self) -> ElGamalCiphertext:
         """
         Add the individual ballot_selections `message` fields together, suitable for use
         in a Chaum-Pedersen proof.
         """
-        return elgamal_add(*[selection.message for selection in self.ballot_selections])
+        return _ciphertext_ballot_elgamal_accumulate(self.ballot_selections)
 
     def is_valid_encryption(
         self, seed_hash: ElementModQ, elgamal_public_key: ElementModP
@@ -488,6 +461,88 @@ class CiphertextBallotContest(ElectionObjectBase, CryptoHashCheckable):
         # Verify the sum of the selections matches the proof
         elgamal_accumulation = self.elgamal_accumulate()
         return self.proof.is_valid(elgamal_accumulation, elgamal_public_key)
+
+
+def _ciphertext_ballot_elgamal_accumulate(
+    ballot_selections: List[CiphertextBallotSelection],
+) -> ElGamalCiphertext:
+    return elgamal_add(*[selection.message for selection in ballot_selections])
+
+
+def _ciphertext_ballot_context_crypto_hash(
+    object_id: str,
+    ballot_selections: List[CiphertextBallotSelection],
+    seed_hash: ElementModQ,
+) -> ElementModQ:
+    if len(ballot_selections) == 0:
+        log_warning(
+            f"mismatching ballot_selections state: {object_id} expected(some), actual(none)"
+        )
+        return ZERO_MOD_Q
+
+    selection_hashes = [selection.crypto_hash for selection in ballot_selections]
+
+    return hash_elems(object_id, seed_hash, *selection_hashes)
+
+
+def _ciphertext_ballot_contest_aggregate_nonce(
+    object_id: str, ballot_selections: List[CiphertextBallotSelection]
+) -> Optional[ElementModQ]:
+    selection_nonces: List[ElementModQ] = list()
+    for selection in ballot_selections:
+        if selection.nonce is None:
+            log_warning(
+                f"missing nonce values for contest {object_id} cannot calculate aggregate nonce"
+            )
+            return None
+        else:
+            selection_nonces.append(selection.nonce)
+
+    return add_q(*selection_nonces)
+
+
+def make_ciphertext_ballot_contest(
+    object_id: str,
+    description_hash: ElementModQ,
+    ballot_selections: List[CiphertextBallotSelection],
+    elgamal_public_key: ElementModP,
+    proof_seed: ElementModQ,
+    number_elected: int,
+    crypto_hash: Optional[ElementModQ] = None,
+    proof: Optional[ConstantChaumPedersenProof] = None,
+    nonce: Optional[ElementModQ] = None,
+) -> CiphertextBallotContest:
+    """
+    Constructs a `CipherTextBallotContest` object. Most of the parameters here match up to fields
+    in the class, but this helper function will optionally compute a Chaum-Pedersen proof if the
+    ballot selections include their encryption nonces. Likewise, if a crypto_hash is not provided,
+    it will be derived from the other fields.
+    """
+    if crypto_hash is None:
+        crypto_hash = _ciphertext_ballot_context_crypto_hash(
+            object_id, ballot_selections, description_hash
+        )
+
+    aggregate = _ciphertext_ballot_contest_aggregate_nonce(object_id, ballot_selections)
+    if proof is None:
+        proof = flatmap_optional(
+            aggregate,
+            lambda ag: make_constant_chaum_pedersen(
+                message=_ciphertext_ballot_elgamal_accumulate(ballot_selections),
+                constant=number_elected,
+                r=ag,
+                k=elgamal_public_key,
+                seed=proof_seed,
+            ),
+        )
+    return CiphertextBallotContest(
+        object_id=object_id,
+        description_hash=description_hash,
+        ballot_selections=ballot_selections,
+        nonce=nonce,
+        crypto_hash=crypto_hash,
+        proof=proof,
+    )
 
 
 @dataclass

--- a/src/electionguard/encrypt.py
+++ b/src/electionguard/encrypt.py
@@ -8,6 +8,8 @@ from .ballot import (
     PlaintextBallot,
     PlaintextBallotContest,
     PlaintextBallotSelection,
+    make_ciphertext_ballot_contest,
+    make_ciphertext_ballot_selection,
 )
 
 from .election import (
@@ -171,7 +173,7 @@ def encrypt_selection(
     # TODO: ISSUE #35: encrypt/decrypt: encrypt the extended_data field
 
     # Create the return object
-    encrypted_selection = CiphertextBallotSelection(
+    encrypted_selection = make_ciphertext_ballot_selection(
         object_id=selection.object_id,
         description_hash=selection_description_hash,
         message=get_optional(elgamal_encryption),
@@ -327,7 +329,7 @@ def encrypt_contest(
         )
 
     # Create the return object
-    encrypted_contest = CiphertextBallotContest(
+    encrypted_contest = make_ciphertext_ballot_contest(
         object_id=contest.object_id,
         description_hash=contest_description_hash,
         ballot_selections=encrypted_selections,

--- a/src/electionguard/publish.py
+++ b/src/electionguard/publish.py
@@ -1,11 +1,11 @@
-from jsons import set_serializer, dump
+from jsons import set_serializer, dump, set_validator, set_deserializer
 from os import mkdir, path
 from typing import List
 
 from .ballot_box import CiphertextBallot
 from .decryption_mediator import PlaintextTally
 from .election import CiphertextElectionContext, ElectionConstants, ElectionDescription
-from .group import ElementModP, ElementModQ
+from .group import ElementModP, ElementModQ, int_to_p_unchecked, int_to_q_unchecked
 from .key_ceremony import CoefficientValidationSet
 from .tally import CiphertextTally
 
@@ -75,3 +75,16 @@ def set_serializers() -> None:
     set_serializer(lambda q, **_: str(q), ElementModQ)
     set_serializer(lambda tally, **_: dump(tally.cast), CiphertextTally)
     set_serializer(lambda tally, **_: dump(tally.contests), PlaintextTally)
+
+
+def set_deserializers() -> None:
+    """Set deserializers and validators for json to use to cast specific classes"""
+    set_deserializer(
+        lambda p_as_int, cls, **_: int_to_p_unchecked(p_as_int), ElementModP
+    )
+    set_validator(lambda p: p.is_in_bounds(), ElementModP)
+
+    set_deserializer(
+        lambda q_as_int, cls, **_: int_to_q_unchecked(q_as_int), ElementModQ
+    )
+    set_validator(lambda q: q.is_in_bounds(), ElementModQ)

--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -1,8 +1,6 @@
 from os import path
 from dataclasses import dataclass
 from jsons import (
-    KEY_TRANSFORMER_CAMELCASE,
-    KEY_TRANSFORMER_SNAKECASE,
     dumps,
     loads,
     JsonsError,
@@ -14,8 +12,6 @@ T = TypeVar("T")
 JSON_FILE_EXTENSION: str = ".json"
 WRITE: str = "w"
 JSON_PARSE_ERROR = '{"error": "Object could not be parsed due to json issue"}'
-
-# base10 as string for ElementModP and ElementModQ
 
 
 @dataclass
@@ -30,15 +26,7 @@ class Serializable(Generic[T]):
         :return: the json representation of this object
         """
         try:
-            return cast(
-                str,
-                dumps(
-                    self,
-                    strip_privates=True,
-                    strip_nulls=True,
-                    key_transformer=KEY_TRANSFORMER_CAMELCASE,
-                ),
-            )
+            return cast(str, dumps(self, strip_privates=True, strip_nulls=True))
         except JsonsError:
             return JSON_PARSE_ERROR
 
@@ -53,7 +41,7 @@ class Serializable(Generic[T]):
         """
         Deserialize the provided data string into the specified instance
         """
-        return cast(T, loads(data, cls, key_transformer=KEY_TRANSFORMER_SNAKECASE))
+        return cast(T, loads(data, cls))
 
 
 def write_json_file(json_data: str, file_name: str, file_path: str = "") -> None:

--- a/src/electionguardtest/data/ballot_in_simple.json
+++ b/src/electionguardtest/data/ballot_in_simple.json
@@ -1,18 +1,18 @@
 {
-    "objectId": "some-external-id-string-123",
-    "ballotStyle": "jefferson-county-ballot-style",
+    "object_id": "some-external-id-string-123",
+    "ballot_style": "jefferson-county-ballot-style",
     "contests": [
         {
-            "objectId": "justice-supreme-court",
-            "ballotSelections": [
+            "object_id": "justice-supreme-court",
+            "ballot_selections": [
                 {
-                    "objectId": "john-adams-selection",
+                    "object_id": "john-adams-selection",
                     "plaintext": "True"
                 },
                 {
-                    "objectId": "write-in-selection",
+                    "object_id": "write-in-selection",
                     "plaintext": "True",
-                    "extraData": "some writein value"
+                    "extra_data": "some writein value"
                 }
             ]
         }

--- a/src/electionguardtest/data/election_manifest_simple.json
+++ b/src/electionguardtest/data/election_manifest_simple.json
@@ -1,11 +1,11 @@
 {
-    "geopoliticalUnits": [
+    "geopolitical_units": [
         {
-            "objectId": "jefferson-county",
+            "object_id": "jefferson-county",
             "name": "Jefferson County",
             "type": "county",
-            "contactInformation": {
-                "addressLine": [
+            "contact_information": {
+                "address_line": [
                     "1234 Samuel Adams Way",
                     "Jefferson, Hamilton 999999"
                 ],
@@ -25,11 +25,11 @@
             }
         },
         {
-            "objectId": "harrison-township",
+            "object_id": "harrison-township",
             "name": "Harrison Township",
             "type": "township",
-            "contactInformation": {
-                "addressLine": [
+            "contact_information": {
+                "address_line": [
                     "1234 Thorton Drive",
                     "Harrison, Hamilton 999999"
                 ],
@@ -49,11 +49,11 @@
             }
         },
         {
-            "objectId": "harrison-township-precinct-east",
+            "object_id": "harrison-township-precinct-east",
             "name": "Harrison Township Precinct",
             "type": "township",
-            "contactInformation": {
-                "addressLine": [
+            "contact_information": {
+                "address_line": [
                     "1234 Thorton Drive",
                     "Harrison, Hamilton 999999"
                 ],
@@ -73,11 +73,11 @@
             }
         },
         {
-            "objectId": "rutledge-elementary",
+            "object_id": "rutledge-elementary",
             "name": "Rutledge Elementary School district",
             "type": "school",
-            "contactInformation": {
-                "addressLine": [
+            "contact_information": {
+                "address_line": [
                     "1234 Wolcott Parkway",
                     "Harrison, Hamilton 999999"
                 ],
@@ -99,10 +99,10 @@
     ],
     "parties": [
         {
-            "objectId": "whig",
+            "object_id": "whig",
             "abbreviation": "WHI",
             "color": "AAAAAA",
-            "logoUri": "http://some/path/to/whig.svg",
+            "logo_uri": "http://some/path/to/whig.svg",
             "name": {
                 "text": [
                     {
@@ -113,10 +113,10 @@
             }
         },
         {
-            "objectId": "federalist",
+            "object_id": "federalist",
             "abbreviation": "FED",
             "color": "CCCCCC",
-            "logoUri": "http://some/path/to/federalist.svg",
+            "logo_uri": "http://some/path/to/federalist.svg",
             "name": {
                 "text": [
                     {
@@ -127,10 +127,10 @@
             }
         },
         {
-            "objectId": "democratic-republican",
+            "object_id": "democratic-republican",
             "abbreviation": "DEMREP",
             "color": "EEEEEE",
-            "logoUri": "http://some/path/to/democratic-repulbican.svg",
+            "logo_uri": "http://some/path/to/democratic-repulbican.svg",
             "name": {
                 "text": [
                     {
@@ -143,8 +143,8 @@
     ],
     "candidates": [
         {
-            "objectId": "benjamin-franklin",
-            "ballotName": {
+            "object_id": "benjamin-franklin",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "Benjamin Franklin",
@@ -152,11 +152,11 @@
                     }
                 ]
             },
-            "partyId": "whig"
+            "party_id": "whig"
         },
         {
-            "objectId": "john-adams",
-            "ballotName": {
+            "object_id": "john-adams",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "John Adams",
@@ -164,11 +164,11 @@
                     }
                 ]
             },
-            "partyId": "federalist"
+            "party_id": "federalist"
         },
         {
-            "objectId": "john-hancock",
-            "ballotName": {
+            "object_id": "john-hancock",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "John Hancock",
@@ -176,11 +176,11 @@
                     }
                 ]
             },
-            "partyId": "democratic-republican"
+            "party_id": "democratic-republican"
         },
         {
-            "objectId": "write-in",
-            "ballotName": {
+            "object_id": "write-in",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "Write In Candidate",
@@ -192,11 +192,11 @@
                     }
                 ]
             },
-            "isWriteIn": true
+            "is_write_in": true
         },
         {
-            "objectId": "referendum-pineapple-affirmative",
-            "ballotName": {
+            "object_id": "referendum-pineapple-affirmative",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "Pineapple should be banned on pizza",
@@ -206,8 +206,8 @@
             }
         },
         {
-            "objectId": "referendum-pineapple-negative",
-            "ballotName": {
+            "object_id": "referendum-pineapple-negative",
+            "ballot_name": {
                 "text": [
                     {
                         "value": "Pineapple should not be banned on pizza",
@@ -220,31 +220,31 @@
     "contests": [
         {
             "@type": "CandidateContest",
-            "objectId": "justice-supreme-court",
-            "sequenceOrder": 0,
-            "ballotSelections": [
+            "object_id": "justice-supreme-court",
+            "sequence_order": 0,
+            "ballot_selections": [
                 {
-                    "objectId": "john-adams-selection",
-                    "sequenceOrder": 0,
-                    "candidateId": "john-adams"
+                    "object_id": "john-adams-selection",
+                    "sequence_order": 0,
+                    "candidate_id": "john-adams"
                 },
                 {
-                    "objectId": "benjamin-franklin-selection",
-                    "sequenceOrder": 1,
-                    "candidateId": "benjamin-franklin"
+                    "object_id": "benjamin-franklin-selection",
+                    "sequence_order": 1,
+                    "candidate_id": "benjamin-franklin"
                 },
                 {
-                    "objectId": "john-hancock-selection",
-                    "sequenceOrder": 2,
-                    "candidateId": "john-hancock"
+                    "object_id": "john-hancock-selection",
+                    "sequence_order": 2,
+                    "candidate_id": "john-hancock"
                 },
                 {
-                    "objectId": "write-in-selection",
-                    "sequenceOrder": 3,
-                    "candidateId": "write-in"
+                    "object_id": "write-in-selection",
+                    "sequence_order": 3,
+                    "candidate_id": "write-in"
                 }
             ],
-            "ballotTitle": {
+            "ballot_title": {
                 "text": [
                     {
                         "value": "Justice of the Supreme Court",
@@ -256,7 +256,7 @@
                     }
                 ]
             },
-            "ballotSubtitle": {
+            "ballot_subtitle": {
                 "text": [
                     {
                         "value": "Please choose up to two candidates",
@@ -268,33 +268,33 @@
                     }
                 ]
             },
-            "voteVariation": "n_of_m",
-            "electoralDistrictId": "jefferson-county",
+            "vote_variation": "n_of_m",
+            "electoral_district_id": "jefferson-county",
             "name": "Justice of the Supreme Court",
-            "primaryPartyIds": [
+            "primary_party_ids": [
                 "whig",
                 "federalist"
             ],
-            "numberElected": 2,
-            "votesAllowed": 2
+            "number_elected": 2,
+            "votes_allowed": 2
         },
         {
             "@type": "ReferendumContest",
-            "objectId": "referendum-pineapple",
-            "sequenceOrder": 1,
-            "ballotSelections": [
+            "object_id": "referendum-pineapple",
+            "sequence_order": 1,
+            "ballot_selections": [
                 {
-                    "objectId": "referendum-pineapple-affirmative-selection",
-                    "sequenceOrder": 0,
-                    "candidateId": "referendum-pineapple-affirmative"
+                    "object_id": "referendum-pineapple-affirmative-selection",
+                    "sequence_order": 0,
+                    "candidate_id": "referendum-pineapple-affirmative"
                 },
                 {
-                    "objectId": "referendum-pineapple-negative-selection",
-                    "sequenceOrder": 1,
-                    "candidateId": "referendum-pineapple-negative"
+                    "object_id": "referendum-pineapple-negative-selection",
+                    "sequence_order": 1,
+                    "candidate_id": "referendum-pineapple-negative"
                 }
             ],
-            "ballotTitle": {
+            "ballot_title": {
                 "text": [
                     {
                         "value": "Should pineapple be banned on pizza?",
@@ -306,7 +306,7 @@
                     }
                 ]
             },
-            "ballotSubtitle": {
+            "ballot_subtitle": {
                 "text": [
                     {
                         "value": "The township considers this issue to be very important",
@@ -318,30 +318,30 @@
                     }
                 ]
             },
-            "voteVariation": "one_of_m",
-            "electoralDistrictId": "harrison-township",
+            "vote_variation": "one_of_m",
+            "electoral_district_id": "harrison-township",
             "name": "The Pineapple Question",
-            "numberElected": 1,
-            "votesAllowed": 1
+            "number_elected": 1,
+            "votes_allowed": 1
         }
     ],
-    "ballotStyles": [
+    "ballot_styles": [
         {
-            "objectId": "jefferson-county-ballot-style",
-            "geopoliticalUnitIds": [
+            "object_id": "jefferson-county-ballot-style",
+            "geopolitical_unit_ids": [
                 "jefferson-county"
             ]
         },
         {
-            "objectId": "harrison-township-ballot-style",
-            "geopoliticalUnitIds": [
+            "object_id": "harrison-township-ballot-style",
+            "geopolitical_unit_ids": [
                 "jefferson-county",
                 "harrison-township"
             ]
         },
         {
-            "objectId": "harrison-township-precinct-east-ballot-style",
-            "geopoliticalUnitIds": [
+            "object_id": "harrison-township-precinct-east-ballot-style",
+            "geopolitical_unit_ids": [
                 "jefferson-county",
                 "harrison-township",
                 "harrison-township-precinct-east",
@@ -349,8 +349,8 @@
             ]
         },
         {
-            "objectId": "rutledge-elementary-ballot-style",
-            "geopoliticalUnitIds": [
+            "object_id": "rutledge-elementary-ballot-style",
+            "geopolitical_unit_ids": [
                 "jefferson-county",
                 "harrison-township",
                 "rutledge-elementary"
@@ -369,8 +369,8 @@
             }
         ]
     },
-    "contactInformation": {
-        "addressLine": [
+    "contact_information": {
+        "address_line": [
             "1234 Paul Revere Run",
             "Jefferson, Hamilton 999999"
         ],
@@ -396,8 +396,8 @@
             }
         ]
     },
-    "startDate": "2020-03-01T08:00:00-05:00",
-    "endDate": "2020-03-01T20:00:00-05:00",
-    "electionScopeId": "jefferson-county-primary",
+    "start_date": "2020-03-01T08:00:00-05:00",
+    "end_date": "2020-03-01T20:00:00-05:00",
+    "election_scope_id": "jefferson-county-primary",
     "type": "primary"
 }

--- a/src/electionguardtest/data/plaintext_ballots_simple.json
+++ b/src/electionguardtest/data/plaintext_ballots_simple.json
@@ -1,76 +1,57 @@
 [
     {
-        "objectId": "1048ce32-f1b1-4b05-b7fb-8c615ac842ee",
-        "ballotStyle": "jefferson-county-ballot-style",
+        "object_id": "1048ce32-f1b1-4b05-b7fb-8c615ac842ee",
+        "ballot_style": "jefferson-county-ballot-style",
         "contests": [
             {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
                     {
-                        "objectId": "john-adams-selection",
+                        "object_id": "john-adams-selection",
                         "plaintext": "True"
                     },
                     {
-                        "objectId": "write-in-selection",
+                        "object_id": "write-in-selection",
                         "plaintext": "True",
-                        "extraData": "Susan B. Anthony"
+                        "extra_data": "Susan B. Anthony"
                     }
                 ]
             }
         ]
     },
     {
-        "objectId": "03a29d15-667c-4ac8-afd7-549f19b8e4eb",
-        "ballotStyle": "jefferson-county-ballot-style",
+        "object_id": "03a29d15-667c-4ac8-afd7-549f19b8e4eb",
+        "ballot_style": "jefferson-county-ballot-style",
         "contests": [
             {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
                     {
-                        "objectId": "john-adams-selection",
+                        "object_id": "john-adams-selection",
                         "plaintext": "True"
                     },
                     {
-                        "objectId": "write-in-selection",
+                        "object_id": "write-in-selection",
                         "plaintext": "True",
-                        "extraData": "Susan B. Anthony"
+                        "extra_data": "Susan B. Anthony"
                     }
                 ]
             }
         ]
     },
     {
-        "objectId": "25a7111b-4334-425a-87c1-f7a49f42b3a2",
-        "ballotStyle": "jefferson-county-ballot-style",
+        "object_id": "25a7111b-4334-425a-87c1-f7a49f42b3a2",
+        "ballot_style": "jefferson-county-ballot-style",
         "contests": [
             {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
                     {
-                        "objectId": "john-adams-selection",
+                        "object_id": "john-adams-selection",
                         "plaintext": "True"
                     },
                     {
-                        "objectId": "benjamin-franklin-selection",
-                        "plaintext": "True"
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "objectId": "69aeacb4-64c6-4205-9bb2-5fb6b3b3ea58",
-        "ballotStyle": "harrison-township-ballot-style",
-        "contests": [
-            {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
-                    {
-                        "objectId": "john-adams-selection",
-                        "plaintext": "True"
-                    },
-                    {
-                        "objectId": "john-hancock-selection",
+                        "object_id": "benjamin-franklin-selection",
                         "plaintext": "True"
                     }
                 ]
@@ -78,27 +59,46 @@
         ]
     },
     {
-        "objectId": "5a150c74-a2cb-47f6-b575-165ba8a4ce53",
-        "ballotStyle": "harrison-township-ballot-style",
+        "object_id": "69aeacb4-64c6-4205-9bb2-5fb6b3b3ea58",
+        "ballot_style": "harrison-township-ballot-style",
         "contests": [
             {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
                     {
-                        "objectId": "john-adams-selection",
+                        "object_id": "john-adams-selection",
                         "plaintext": "True"
                     },
                     {
-                        "objectId": "john-hancock-selection",
+                        "object_id": "john-hancock-selection",
+                        "plaintext": "True"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "object_id": "5a150c74-a2cb-47f6-b575-165ba8a4ce53",
+        "ballot_style": "harrison-township-ballot-style",
+        "contests": [
+            {
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
+                    {
+                        "object_id": "john-adams-selection",
+                        "plaintext": "True"
+                    },
+                    {
+                        "object_id": "john-hancock-selection",
                         "plaintext": "True"
                     }
                 ]
             },
             {
-                "objectId": "referendum-pineapple",
-                "ballotSelections": [
+                "object_id": "referendum-pineapple",
+                "ballot_selections": [
                     {
-                        "objectId": "referendum-pineapple-affirmative-selection",
+                        "object_id": "referendum-pineapple-affirmative-selection",
                         "plaintext": "True"
                     }
                 ]
@@ -106,28 +106,28 @@
         ]
     },
     {
-        "objectId": "9fee0e77-cfd2-401a-a210-93bbc4dd30ef",
-        "ballotStyle": "harrison-township-ballot-style",
+        "object_id": "9fee0e77-cfd2-401a-a210-93bbc4dd30ef",
+        "ballot_style": "harrison-township-ballot-style",
         "contests": [
             {
-                "objectId": "justice-supreme-court",
-                "ballotSelections": [
+                "object_id": "justice-supreme-court",
+                "ballot_selections": [
                     {
-                        "objectId": "john-adams-selection",
+                        "object_id": "john-adams-selection",
                         "plaintext": "True"
                     },
                     {
-                        "objectId": "write-in-selection",
+                        "object_id": "write-in-selection",
                         "plaintext": "True",
-                        "extraData": "Susan B. Anthony"
+                        "extra_data": "Susan B. Anthony"
                     }
                 ]
             },
             {
-                "objectId": "referendum-pineapple",
-                "ballotSelections": [
+                "object_id": "referendum-pineapple",
+                "ballot_selections": [
                     {
-                        "objectId": "referendum-pineapple-negative-selection",
+                        "object_id": "referendum-pineapple-negative-selection",
                         "plaintext": "True"
                     }
                 ]

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -13,7 +13,7 @@ from electionguard.election import (
 )
 from electionguard.tally import CiphertextTally
 
-from electionguard.publish import publish, RESULTS_DIR
+from electionguard.publish import publish, RESULTS_DIR, set_deserializers
 
 from electionguard.group import ONE_MOD_Q, ONE_MOD_P
 
@@ -47,3 +47,7 @@ class TestPublish(TestCase):
 
         # Cleanup
         rmtree(RESULTS_DIR)
+
+    def test_setup_deserialization(self) -> None:
+        # Act
+        set_deserializers()


### PR DESCRIPTION
### Issue

Fixes #122 

### Description
Makes the warning conditional on the instance type of the CiphertextBallot. If it's a CiphertextAcceptedBallot, then no warning is generated. Otherwise, behavior is identical.

(This patch is only relevant to the `fix/deserialization-issues` branch, where it's -3+4 lines. If you compare it to `main`, it's much bigger.)

### Testing
In regular use, should have no effect on testing. But logs will be cleaner, easier to read.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!