### PR TITLE
🐛 Resolve Deprecation warning for collections

### DIFF
--- a/src/electionguard/data_store.py
+++ b/src/electionguard/data_store.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 
 from typing import (
     Dict,
@@ -113,3 +113,8 @@ class ReadOnlyDataStore(Generic[T, U], Mapping):
 
     def __iter__(self) -> Iterator:
         return iter(self._data.items())
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ReadOnlyDataStore):
+            return False
+        return ReadOnlyDataStore.__eq__(self, other)


### PR DESCRIPTION


### Issue
Fixes #102 

### Description
Resolves this warning:
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working

### Testing
- Existing test suite

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!