### PR TITLE
Fix/discrete log async

### DIFF
--- a/src/electionguard/dlog.py
+++ b/src/electionguard/dlog.py
@@ -9,7 +9,6 @@ __dlog_cache: Dict[ElementModP, int] = {ONE_MOD_P: 0}
 __dlog_max_elem = ONE_MOD_P
 __dlog_max_exp = 0
 
-# initialized inside __discrete_log_internal
 __dlog_lock: Optional[asyncio.Lock] = None
 
 
@@ -41,15 +40,7 @@ async def __discrete_log_internal(e: ElementModP) -> int:
     global __dlog_lock
 
     if __dlog_lock is None:
-        # We cannot run asyncio.Lock() if we don't have an "event loop", which
-        # can happen if we're running in certain environments. The solution
-        # is to put this bit of initialization into an async function, which
-        # is where we happen to be right now. With Python's relatively simple
-        # concurrency model, we don't have to worry about multiple threads
-        # arriving here simultaneously. This code will run exactly once. If
-        # you're using one of the many multiprocessing libraries, this will
-        # run exactly once per process.
-
+        # Initialize the lock on on first function call per process
         __dlog_lock = asyncio.Lock()
 
     async with __dlog_lock:

--- a/src/electionguard/dlog.py
+++ b/src/electionguard/dlog.py
@@ -1,14 +1,16 @@
 # support for computing discrete logs, with a cache so they're never recomputed
 
 import asyncio
-from typing import Dict
+from typing import Dict, Optional
 
 from .group import G, ElementModP, ONE_MOD_P, mult_p, int_to_p_unchecked
 
 __dlog_cache: Dict[ElementModP, int] = {ONE_MOD_P: 0}
 __dlog_max_elem = ONE_MOD_P
 __dlog_max_exp = 0
-__dlog_lock = asyncio.Lock()
+
+# initialized inside __discrete_log_internal
+__dlog_lock: Optional[asyncio.Lock] = None
 
 
 def discrete_log(e: ElementModP) -> int:
@@ -37,6 +39,18 @@ async def __discrete_log_internal(e: ElementModP) -> int:
     global __dlog_max_elem
     global __dlog_max_exp
     global __dlog_lock
+
+    if __dlog_lock is None:
+        # We cannot run asyncio.Lock() if we don't have an "event loop", which
+        # can happen if we're running in certain environments. The solution
+        # is to put this bit of initialization into an async function, which
+        # is where we happen to be right now. With Python's relatively simple
+        # concurrency model, we don't have to worry about multiple threads
+        # arriving here simultaneously. This code will run exactly once. If
+        # you're using one of the many multiprocessing libraries, this will
+        # run exactly once per process.
+
+        __dlog_lock = asyncio.Lock()
 
     async with __dlog_lock:
         g = int_to_p_unchecked(G)


### PR DESCRIPTION
### Issue
Fixes #130 

### Description
I'm working on getting EG to work with ray.io, a cluster computing framework. I ran into one issue with async code in dlog.py. The gist of it is that the call to initialize __dlog_lock was failing, and I was getting an error about a missing "event loop". Turns out, the way Ray was running the code was tickling this issue.

The solution is really straightforward: delay initialization of the lock variable until you're inside __discrete_log_internal.

### Testing
The existing test suite still works fine.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!