### PR TITLE
serialize "big" integers as base64 strings while "small" integers stay as integers

### DIFF
--- a/src/electionguard/election.py
+++ b/src/electionguard/election.py
@@ -3,9 +3,10 @@ from datetime import datetime
 from enum import Enum, unique
 from typing import cast, List, Optional, Set, Any
 
+from gmpy2 import mpz
 from .ballot import _list_eq
 from .election_object_base import ElectionObjectBase
-from .group import Q, P, R, G, ElementModQ, ElementModP
+from .group import Q, P, R, G, ElementModQ, ElementModP, int_to_p_unchecked
 from .hash import CryptoHashable, hash_elems
 from .logs import log_warning
 from .serializable import Serializable
@@ -818,16 +819,21 @@ class ElectionConstants(Serializable):
     The constants for mathematical functions during the election. 
     """
 
-    large_prime = P
+    # While having large_prime=P isn't a valid member of the integers mod P, doing
+    # it this way will ensure that ElectionConstants's members serialize as strings rather
+    # than as integers. That will improve compatibility with languages where integers
+    # aren't automatically bigints.
+
+    large_prime = int_to_p_unchecked(P)
     """large prime or p"""
 
-    small_prime = Q
+    small_prime = int_to_p_unchecked(Q)
     """small prime or q"""
 
-    cofactor = R
+    cofactor = int_to_p_unchecked(R)
     """cofactor or r"""
 
-    generator = G
+    generator = int_to_p_unchecked(G)
     """generator or g"""
 
 

--- a/src/electionguard/election.py
+++ b/src/electionguard/election.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from enum import Enum, unique
 from typing import cast, List, Optional, Set, Any
 
-from gmpy2 import mpz
 from .ballot import _list_eq
 from .election_object_base import ElectionObjectBase
 from .group import Q, P, R, G, ElementModQ, ElementModP, int_to_p_unchecked

--- a/src/electionguard/election.py
+++ b/src/electionguard/election.py
@@ -5,7 +5,7 @@ from typing import cast, List, Optional, Set, Any
 
 from .ballot import _list_eq
 from .election_object_base import ElectionObjectBase
-from .group import Q, P, R, G, ElementModQ, ElementModP, int_to_p_unchecked
+from .group import Q, P, R, G, ElementModQ, ElementModP
 from .hash import CryptoHashable, hash_elems
 from .logs import log_warning
 from .serializable import Serializable
@@ -823,16 +823,16 @@ class ElectionConstants(Serializable):
     # than as integers. That will improve compatibility with languages where integers
     # aren't automatically bigints.
 
-    large_prime = int_to_p_unchecked(P)
+    large_prime = P
     """large prime or p"""
 
-    small_prime = int_to_p_unchecked(Q)
+    small_prime = Q
     """small prime or q"""
 
-    cofactor = int_to_p_unchecked(R)
+    cofactor = R
     """cofactor or r"""
 
-    generator = int_to_p_unchecked(G)
+    generator = G
     """generator or g"""
 
 

--- a/src/electionguard/election.py
+++ b/src/electionguard/election.py
@@ -818,11 +818,6 @@ class ElectionConstants(Serializable):
     The constants for mathematical functions during the election. 
     """
 
-    # While having large_prime=P isn't a valid member of the integers mod P, doing
-    # it this way will ensure that ElectionConstants's members serialize as strings rather
-    # than as integers. That will improve compatibility with languages where integers
-    # aren't automatically bigints.
-
     large_prime = P
     """large prime or p"""
 

--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -112,8 +112,9 @@ def int_to_maybe_base64(i: int) -> Union[str, int]:
 
 def maybe_base64_to_int(i: Union[str, int]) -> int:
     """
-    Given a maybe-encoded big-endian base64-encoded non-negative integer, such as
-    might have been returned by `int_to_base_64_maybe`, returns that integer, decoded.
+    Given a maybe-encoded big-endian base64 non-negative integer, or just a regular
+    integer, such as might have been returned by `int_to_maybe_base64`, returns
+    that integer, decoded.
     :param i: a base64-encode integer, or just an integer
     :return: an integer
     """

--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -95,7 +95,7 @@ def int_to_maybe_base64(i: int) -> Union[str, int]:
     Given a non-negative integer, returns a big-endian base64 encoding of the integer,
     if it's bigger than `ENCODE_THRESHOLD`, otherwise the input integer is returned.
     :param i: any non-negative integer
-    :return: a string in base-64 or just the input integer, if it's "small".
+    :return: a string in base64 or just the input integer, if it's "small".
     """
     assert i >= 0, "int_to_maybe_base64 does not accept negative numbers"
 
@@ -115,7 +115,7 @@ def maybe_base64_to_int(i: Union[str, int]) -> int:
     Given a maybe-encoded big-endian base64 non-negative integer, or just a regular
     integer, such as might have been returned by `int_to_maybe_base64`, returns
     that integer, decoded.
-    :param i: a base64-encode integer, or just an integer
+    :param i: a base64-encoded integer, or just an integer
     :return: an integer
     """
 

--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -97,7 +97,9 @@ def int_to_maybe_base64(i: int) -> Union[str, int]:
     :param i: any non-negative integer
     :return: a string in base64 or just the input integer, if it's "small".
     """
-    assert i >= 0, "int_to_maybe_base64 does not accept negative numbers"
+
+    if i < 0:
+        raise ValueError("int_to_maybe_base64 does not accept negative numbers")
 
     # Coercing mpz integers to vanilla integers, because we want consistent behavior.
     i = int(i)

--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -90,14 +90,14 @@ def write_json_file(json_data: str, file_name: str, file_path: str = "") -> None
 ENCODE_THRESHOLD: Final[int] = 100_000_000
 
 
-def int_to_base64_maybe(i: int) -> Union[str, int]:
+def int_to_maybe_base64(i: int) -> Union[str, int]:
     """
     Given a non-negative integer, returns a big-endian base64 encoding of the integer,
     if it's bigger than `ENCODE_THRESHOLD`, otherwise the input integer is returned.
     :param i: any non-negative integer
     :return: a string in base-64 or just the input integer, if it's "small".
     """
-    assert i >= 0, "int_to_base64 does not accept negative numbers"
+    assert i >= 0, "int_to_maybe_base64 does not accept negative numbers"
 
     # Coercing mpz integers to vanilla integers, because we want consistent behavior.
     i = int(i)
@@ -131,9 +131,9 @@ def set_serializers() -> None:
     # Local import to minimize jsons usage across files
     from .group import ElementModP, ElementModQ
 
-    set_serializer(lambda p, **_: int_to_base64_maybe(p.to_int()), ElementModP)
-    set_serializer(lambda q, **_: int_to_base64_maybe(q.to_int()), ElementModQ)
-    set_serializer(lambda i, **_: int_to_base64_maybe(i), int)
+    set_serializer(lambda p, **_: int_to_maybe_base64(p.to_int()), ElementModP)
+    set_serializer(lambda q, **_: int_to_maybe_base64(q.to_int()), ElementModQ)
+    set_serializer(lambda i, **_: int_to_maybe_base64(i), int)
     set_serializer(lambda dt, **_: dt.isoformat(), datetime)
 
 

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -12,7 +12,7 @@ from electionguard.serializable import (
     set_serializers,
     write_json_file,
     maybe_base64_to_int,
-    int_to_base64_maybe,
+    int_to_maybe_base64,
     Serializable,
     ENCODE_THRESHOLD,
 )
@@ -49,7 +49,7 @@ class TestSerializable(TestCase):
     @given(elements_mod_p())
     def test_base64_conversions(self, p: ElementModP) -> None:
         i = p.to_int()
-        self.assertEqual(i, maybe_base64_to_int(int_to_base64_maybe(i)))
+        self.assertEqual(i, maybe_base64_to_int(int_to_maybe_base64(i)))
 
     def test_election_constants_serialization(self) -> None:
         # ElectionConstants has large integers that we want to encode

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -1,14 +1,35 @@
-from unittest import TestCase
+from dataclasses import dataclass
 from os import remove
+from unittest import TestCase
 
+from hypothesis import given
+from hypothesis.strategies import integers
+
+from electionguard.election import ElectionConstants
+from electionguard.group import ElementModP
 from electionguard.serializable import (
     set_deserializers,
     set_serializers,
     write_json_file,
+    maybe_base64_to_int,
+    int_to_base64_maybe,
+    Serializable,
+    ENCODE_THRESHOLD,
 )
+from electionguardtest.group import elements_mod_p
+
+
+@dataclass(eq=True)
+class BigAndSmall(Serializable):
+    small: int
+    big: int
 
 
 class TestSerializable(TestCase):
+    def setUp(self) -> None:
+        set_serializers()
+        set_deserializers()
+
     def test_write_json_file(self) -> None:
         # Arrange
         json_data = '{ "test" : 1 }'
@@ -25,10 +46,24 @@ class TestSerializable(TestCase):
         # Cleanup
         remove(json_file)
 
-    def test_setup_serialization(self) -> None:
-        # Act
-        set_serializers()
+    @given(elements_mod_p())
+    def test_base64_conversions(self, p: ElementModP) -> None:
+        i = p.to_int()
+        self.assertEqual(i, maybe_base64_to_int(int_to_base64_maybe(i)))
 
-    def test_setup_deserialization(self) -> None:
-        # Act
-        set_deserializers()
+    def test_election_constants_serialization(self) -> None:
+        # ElectionConstants has large integers that we want to encode
+        expected = ElectionConstants()
+        expected_json = expected.to_json()
+        actual = ElectionConstants.from_json(expected_json)
+        self.assertEqual(expected, actual)
+
+    @given(
+        integers(0, ENCODE_THRESHOLD - 1),
+        integers(ENCODE_THRESHOLD, 1000 * ENCODE_THRESHOLD),
+    )
+    def test_big_and_small_serialization(self, small: int, big: int) -> None:
+        expected = BigAndSmall(small, big)
+        expected_json = expected.to_json()
+        actual = BigAndSmall.from_json(expected_json)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
### Issue

Fixes #153 
Fixes #155

### Description
So far as I can tell, this is the one place where we were writing out bigints as JSON integers instead of JSON strings. The fix is to wrap the constants in `ElementModP`, which already has correct treatment by our serialization process.

### Testing
All tests still pass just fine. Seems like this particular structure isn't much used in ElectionGuard-Python. It's used by Arlo-e2e as kind of version-check. If an election is written out with different constants than the current library is using, that's flagged as an error.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!