### PR TITLE
Support command line arguments in sample_generator and fix spoil rate

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Full Test & Coverage
         run: make coverage
       - name: Generate Sample Data
-        run: make generate-sample-data
+        # TODO: Issue #152
+        run: make generate-sample-data SAMPLE_BALLOT_SPOIL_RATE=0
 
   mac_check:
     name: MacOS Check

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ WINDOWS_32BIT_GMPY2 ?= packages/gmpy2-2.0.8-cp38-cp38-win32.whl
 WINDOWS_64BIT_GMPY2 ?= packages/gmpy2-2.0.8-cp38-cp38-win_amd64.whl
 OS ?= $(shell python -c 'import platform; print(platform.system())')
 IS_64_BIT ?= $(shell python -c 'from sys import maxsize; print(maxsize > 2**32)')
+SAMPLE_BALLOT_COUNT ?= 5
+SAMPLE_BALLOT_SPOIL_RATE ?= 50
 
 all: environment install validate lint coverage
 
@@ -136,7 +138,7 @@ dependency-graph-ci:
 
 # Sample Data
 generate-sample-data:
-	pipenv run python src/electionguardtest/sample_generator.py
+	pipenv run python src/electionguardtest/sample_generator.py -n $(SAMPLE_BALLOT_COUNT) -s $(SAMPLE_BALLOT_SPOIL_RATE)
 
 # Package
 package:


### PR DESCRIPTION
### Issue

Fixes #161
Closes #160 

### Description
Adds arguments to the sample generator:

```bash
$ pipenv run python ./src/electionguardtest/sample_generator.py --help
usage: sample_generator.py [-h] [-n <count>] [-s <rate>] [-a]

Generate sample ballot data

optional arguments:
  -h, --help            show this help message and exit
  -n <count>, --number-of-ballots <count>
                        The number of ballots to generate. (default: 5)
  -s <rate>, --spoil-rate <rate>
                        The approximate percentage of total ballots to spoil instead of
                        cast. Provide a number from 0-100. (default: 50)
  -a, --all-guardians   If specified, all guardians will be included. Otherwise, only the
                        threshold number will be included. (default: False)
```

Optional arguments have also been added to the Makefile: `SAMPLE_BALLOT_COUNT` and `SAMPLE_BALLOT_SPOIL_RATE`.  There's no argument for `--all-guardians` because we want to encourage decryption with a quorum.

This also fixes a bug with spoiling the generated ballots.

### Testing
- Verify all tests continue to pass
- Verify that calling `sample_generator.py` with no arguments preserves the original behavior (5 ballots, 50% spoil rate, quorum # of guardians)
- Verify that different parameters for `-n`, `-s`, and `-a` reflect the correct behavior

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!