### PR TITLE
🐛 Change Challenge to use an ElementModQ Value

### DIFF
--- a/src/electionguard/key_ceremony.py
+++ b/src/electionguard/key_ceremony.py
@@ -131,7 +131,7 @@ class ElectionPartialKeyChallenge(NamedTuple):
     The sequence order of the designated guardian
     """
 
-    value: int
+    value: ElementModQ
     coefficient_commitments: List[ElementModP]
     coefficient_proofs: List[SchnorrProof]
 
@@ -264,9 +264,7 @@ def generate_election_partial_key_challenge(
         backup.owner_id,
         backup.designated_id,
         backup.designated_sequence_order,
-        compute_polynomial_coordinate(
-            backup.designated_sequence_order, polynomial
-        ).to_int(),
+        compute_polynomial_coordinate(backup.designated_sequence_order, polynomial),
         backup.coefficient_commitments,
         backup.coefficient_proofs,
     )
@@ -286,7 +284,7 @@ def verify_election_partial_key_challenge(
         challenge.designated_id,
         verifier_id,
         verify_polynomial_coordinate(
-            get_optional(int_to_q(challenge.value)),
+            challenge.value,
             challenge.designated_sequence_order,
             challenge.coefficient_commitments,
         ),


### PR DESCRIPTION
### Issue

Fixes #166 

### Description
- The value for challenge should be ElementModQ instead of int both for serialization and for simplicity

### Testing
- Key ceremony test suite

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!