### PR TITLE
Avoid initializing a scheduler as a default argument

### DIFF
--- a/src/electionguard/decryption.py
+++ b/src/electionguard/decryption.py
@@ -218,11 +218,14 @@ def compute_decryption_share_for_ballot(
     guardian: Guardian,
     ballot: CiphertextAcceptedBallot,
     context: CiphertextElectionContext,
-    scheduler: Scheduler = Scheduler(),
+    scheduler: Optional[Scheduler] = None,
 ) -> Optional[BallotDecryptionShare]:
     """
     Compute the decryption for a single ballot
     """
+    if not scheduler:
+        scheduler = Scheduler()
+
     contests: Dict[CONTEST_ID, CiphertextDecryptionContest] = {}
     for contest in ballot.contests:
         selections: Dict[SELECTION_ID, CiphertextDecryptionSelection] = {}
@@ -285,11 +288,14 @@ def compute_compensated_decryption_share_for_ballot(
     ballot: CiphertextAcceptedBallot,
     context: CiphertextElectionContext,
     decrypt: AuxiliaryDecrypt = rsa_decrypt,
-    scheduler: Scheduler = Scheduler(),
+    scheduler: Optional[Scheduler] = None,
 ) -> Optional[CompensatedBallotDecryptionShare]:
     """
     Compute the decryption for a single ballot
     """
+    if not scheduler:
+        scheduler = Scheduler()
+
     contests: Dict[CONTEST_ID, CiphertextCompensatedDecryptionContest] = {}
     for contest in ballot.contests:
         selections: Dict[SELECTION_ID, CiphertextCompensatedDecryptionSelection] = {}


### PR DESCRIPTION
### Issue

Fixes #174 

### Description
When a Scheduler isn't provided to certain methods, wait to initialize a new one until the method is executing.

### Testing
Linter/tests pass.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚 Thank you!