### PR TITLE
Allow Selection ID to reoccur within a ballot

### DIFF
--- a/src/electionguard/decryption_share.py
+++ b/src/electionguard/decryption_share.py
@@ -371,7 +371,10 @@ def get_tally_shares_for_selection(
 
 
 def get_spoiled_shares_for_selection(
-    ballot_id: str, selection_id: str, shares: Dict[GUARDIAN_ID, TallyDecryptionShare],
+    ballot_id: str,
+    contest_id: str,
+    selection_id: str,
+    shares: Dict[GUARDIAN_ID, TallyDecryptionShare],
 ) -> Dict[GUARDIAN_ID, Tuple[ELECTION_PUBLIC_KEY, CiphertextDecryptionSelection]]:
     """
     Get the spoiled shares for a given selection
@@ -383,12 +386,13 @@ def get_spoiled_shares_for_selection(
         for ballot in share.spoiled_ballots.values():
             if ballot.ballot_id == ballot_id:
                 for contest in ballot.contests.values():
-                    for selection in contest.selections.values():
-                        if selection.object_id == selection_id:
-                            spoiled_shares[share.guardian_id] = (
-                                share.public_key,
-                                selection,
-                            )
+                    if contest.object_id == contest_id:
+                        for selection in contest.selections.values():
+                            if selection.object_id == selection_id:
+                                spoiled_shares[share.guardian_id] = (
+                                    share.public_key,
+                                    selection,
+                                )
     return spoiled_shares
 
 


### PR DESCRIPTION
### Issue

Addresses #168 

### Description

This pull request adds contest ID to the arguments of ```get_spoiled_shares_for_selection```. Since we assume that selection IDs are unique to contests but not entire ballots, I've also added an if statement to the loop for comparing contest IDs to the contest ID passed to the function. This way, duplicate selection IDs from different contests can be differentiated.

### Testing

Code Review

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.
