### PR TITLE
🕙 Use unix epoch to generate ticks

### DIFF
--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -850,7 +850,7 @@ def make_ciphertext_ballot(
     contest_hashes = [contest.crypto_hash for contest in contests]
     contest_hash = hash_elems(object_id, description_hash, *contest_hashes)
 
-    timestamp = to_ticks(datetime.utcnow()) if timestamp is None else timestamp
+    timestamp = to_ticks(datetime.now()) if timestamp is None else timestamp
     if previous_tracking_hash is None:
         previous_tracking_hash = description_hash
     if tracking_hash is None:

--- a/src/electionguard/utils.py
+++ b/src/electionguard/utils.py
@@ -72,12 +72,12 @@ def to_ticks(date_time: datetime) -> int:
     :return: number of ticks
     """
 
-    epoch_milliseconds = (
+    ticks = (
         date_time.timestamp()
         if date_time.tzinfo
         else date_time.astimezone(timezone.utc).timestamp()
     )
-    return int(epoch_milliseconds)
+    return int(ticks)
 
 
 def space_between_capitals(base: str) -> str:

--- a/src/electionguard/utils.py
+++ b/src/electionguard/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from os import mkdir, path
 from re import sub
 from typing import Callable, Optional, TypeVar
@@ -66,14 +66,18 @@ def flatmap_optional(optional: Optional[T], mapper: Callable[[T], U]) -> Optiona
 
 def to_ticks(date_time: datetime) -> int:
     """
-    Return the number of ticks for a date time
+    Return the number of ticks for a date time.
+    Ticks are defined here as number of seconds since the unix epoch (00:00:00 UTC on 1 January 1970)
     :param date_time: Date time to convert
     :return: number of ticks
     """
-    t0 = datetime(1, 1, 1)
-    seconds = int((date_time - t0).total_seconds())
-    ticks = seconds * 10 ** 7
-    return ticks
+
+    epoch_milliseconds = (
+        date_time.timestamp()
+        if date_time.tzinfo
+        else date_time.astimezone(timezone.utc).timestamp()
+    )
+    return int(epoch_milliseconds)
 
 
 def space_between_capitals(base: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,15 +20,17 @@ class TestUtils(TestCase):
         self.assertGreater(ticks, 0)
 
     def test_conversion_to_ticks_with_tz(self):
-        # Act
+        # Arrange
         now = datetime.now()
         now_with_tz = (now).astimezone()
         now_utc_with_tz = now_with_tz.astimezone(timezone.utc)
 
+        # Act
         ticks_now = to_ticks(now)
         ticks_local = to_ticks(now_with_tz)
         ticks_utc = to_ticks(now_utc_with_tz)
 
+        # Assert
         self.assertIsNotNone(ticks_now)
         self.assertIsNotNone(ticks_local)
         self.assertIsNotNone(ticks_utc)
@@ -37,3 +39,15 @@ class TestUtils(TestCase):
         unique_ticks = set([ticks_now, ticks_local, ticks_utc])
         self.assertEqual(1, len(unique_ticks))
         self.assertTrue(ticks_now in unique_ticks)
+
+    def test_conversion_to_ticks_produces_valid_epoch(self):
+        # Arrange
+        now = datetime.now()
+
+        # Act
+        ticks_now = to_ticks(now)
+        now_from_ticks = datetime.fromtimestamp(ticks_now)
+
+        # Assert
+        # Values below seconds are dropped from the epoch
+        self.assertEqual(now.replace(microsecond=0), now_from_ticks)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,39 @@
 from unittest import TestCase
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from electionguard.utils import to_ticks
 
 
 class TestUtils(TestCase):
-    def test_conversion_to_ticks(self):
+    def test_conversion_to_ticks_from_utc(self):
         # Act
-        ticks = to_ticks(datetime.utcnow())
+        ticks = to_ticks(datetime.now(timezone.utc))
 
         self.assertIsNotNone(ticks)
         self.assertGreater(ticks, 0)
+
+    def test_conversion_to_ticks_from_local(self):
+        # Act
+        ticks = to_ticks(datetime.now())
+
+        self.assertIsNotNone(ticks)
+        self.assertGreater(ticks, 0)
+
+    def test_conversion_to_ticks_with_tz(self):
+        # Act
+        now = datetime.now()
+        now_with_tz = (now).astimezone()
+        now_utc_with_tz = now_with_tz.astimezone(timezone.utc)
+
+        ticks_now = to_ticks(now)
+        ticks_local = to_ticks(now_with_tz)
+        ticks_utc = to_ticks(now_utc_with_tz)
+
+        self.assertIsNotNone(ticks_now)
+        self.assertIsNotNone(ticks_local)
+        self.assertIsNotNone(ticks_utc)
+
+        # Ensure all three tick values are the same
+        unique_ticks = set([ticks_now, ticks_local, ticks_utc])
+        self.assertEqual(1, len(unique_ticks))
+        self.assertTrue(ticks_now in unique_ticks)


### PR DESCRIPTION
Fixes #190 

### Description
- Updates the `utils.to_ticks` function to use the unix epoch (seconds since January 1, 1970 UTC)
- Replaces the use of `datetime.utcnow` with `datetime.now`, as [`utcnow` is considered harmful](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and ironically produces the wrong epoch timestamp.

Note: sample data will need to be regenerated, but we have several other hashing/format changes coming and should address that in one sweep.

### Testing
Unit tests for `utils.to_ticks` have been augmented to cover more flavors of datetime.

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.

💚 Thank you!