### PR TITLE
Disable Ascii in serialized json

### DIFF
--- a/src/electionguard/serializable.py
+++ b/src/electionguard/serializable.py
@@ -120,7 +120,7 @@ def write_json(object_to_write: object, strip_privates: bool = True) -> str:
     try:
         json_object = write_json_object(object_to_write, strip_privates)
         json_string = cast(
-            str, dumps(json_object, strip_privates=strip_privates, strip_nulls=True)
+            str, dumps(json_object, strip_privates=strip_privates, strip_nulls=True, ensure_ascii=False)
         )
         return json_string
     except JsonsError:
@@ -138,7 +138,7 @@ def write_json_object(object_to_write: object, strip_privates: bool = True) -> o
     suppress_warnings()
     try:
         json_object = dump(
-            object_to_write, strip_privates=strip_privates, strip_nulls=True
+            object_to_write, strip_privates=strip_privates, strip_nulls=True, ensure_ascii=False
         )
         for key in KEYS_TO_REMOVE:
             _remove_key(json_object, key)


### PR DESCRIPTION
### Issue
*Issue #179 *

Fixes #179 

### Description
*The jsons library depends on json. Added feature  ensure_ascii=False in _dump _and _dumps_ functions in the file electionguard/serializable.py*

### Testing
*Describe the best way to test or validate your PR.*

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [✅]  **DO** check open PR's to avoid duplicates.
- [✅] **DO** keep pull requests small so they can be easily reviewed.
- [✅] **DO** build locally before pushing.
- [✅] **DO** make sure tests pass.
- [✅] **DO** make sure any new changes are documented.
- [✅] **DO** make sure not to introduce any compiler warnings.
- [] ❌**AVOID** breaking the continuous integration build.
- [] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!