### PR TITLE
Spoiled Ballots should be PlaintextBallots when publishing

### DIFF
--- a/src/electionguard/publish.py
+++ b/src/electionguard/publish.py
@@ -68,9 +68,9 @@ def publish(
         ballot.to_json_file(ballot_name, BALLOTS_DIR)
 
     make_directory(SPOILED_DIR)
-    for ballot in spoiled_ballots:
-        ballot_name = BALLOT_PREFIX + ballot.object_id
-        ballot.to_json_file(ballot_name, SPOILED_DIR)
+    for spoiled_ballot in spoiled_ballots:
+        ballot_name = BALLOT_PREFIX + spoiled_ballot.object_id
+        spoiled_ballot.to_json_file(ballot_name, SPOILED_DIR)
 
     ciphertext_tally.to_json_file(ENCRYPTED_TALLY_FILE_NAME, results_directory)
     plaintext_tally.to_json_file(TALLY_FILE_NAME, results_directory)

--- a/src/electionguard/publish.py
+++ b/src/electionguard/publish.py
@@ -38,7 +38,7 @@ def publish(
     constants: ElectionConstants,
     devices: Iterable[EncryptionDevice],
     ciphertext_ballots: Iterable[CiphertextAcceptedBallot],
-    spoiled_ballots: Iterable[CiphertextAcceptedBallot],
+    spoiled_ballots: Iterable[PlaintextBallot],
     ciphertext_tally: PublishedCiphertextTally,
     plaintext_tally: PlaintextTally,
     coefficient_validation_sets: Iterable[CoefficientValidationSet] = None,

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -425,7 +425,7 @@ class TestEndToEndElection(TestCase):
             self.constants,
             [self.device],
             self.ballot_store.all(),
-            self.ciphertext_tally.spoiled_ballots.values(),
+            self.plaintext_tally.spoiled_ballots.values(),
             publish_ciphertext_tally(self.ciphertext_tally),
             self.plaintext_tally,
             self.coefficient_validation_sets,


### PR DESCRIPTION
### Issue
Spoiled Ballots within publish should be Plaintext

Fixes #205 

### Description
ElectionGuard should be publishing (1) the list of plaintext spoiled ballots and (2) all encrypted cast or spoiled ballots aka AcceptedCiphertextBallots.

### Checklist

- [x] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [x] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [x] ❌**AVOID** breaking the continuous integration build.
- [x] ❌**AVOID** making significant changes to the overall architecture.