### PR TITLE
Fix element mod p hash and use enum name in hash

### DIFF
--- a/src/electionguard/election.py
+++ b/src/electionguard/election.py
@@ -175,7 +175,7 @@ class GeopoliticalUnit(ElectionObjectBase, CryptoHashable):
         A hash representation of the object
         """
         return hash_elems(
-            self.object_id, self.name, str(self.type), self.contact_information
+            self.object_id, self.name, str(self.type.name), self.contact_information
         )
 
 
@@ -363,7 +363,7 @@ class ContestDescription(ElectionObjectBase, CryptoHashable):
             self.object_id,
             self.sequence_order,
             self.electoral_district_id,
-            str(self.vote_variation),
+            str(self.vote_variation.name),
             self.ballot_title,
             self.ballot_subtitle,
             self.name,
@@ -566,7 +566,7 @@ class ElectionDescription(Serializable, CryptoHashable):
 
         return hash_elems(
             self.election_scope_id,
-            str(self.type),
+            str(self.type.name),
             to_ticks(self.start_date),
             to_ticks(self.end_date),
             self.name,

--- a/src/electionguard/group.py
+++ b/src/electionguard/group.py
@@ -88,7 +88,7 @@ class ElementModP(NamedTuple):
         Converts from the element to the hex representation of bytes. This is preferable to directly
         accessing `elem`, whose representation might change.
         """
-        h = format(self.elem, "02x")
+        h = format(self.elem, "02X")
         if len(h) % 2:
             h = "0" + h
         return h


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #___

### Description
hashes were hasing on the python enumeration object which is difficult to reproduce across languages

### Testing
run the tests

### Checklist
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] ✅ **DO** check open PR's to avoid duplicates.
- [ ] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [ ] ✅ **DO** make sure tests pass.
- [ ] ✅ **DO** make sure any new changes are documented.
- [ ] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💚Thank you!