### PR TITLE
Spoiled Ballots should be PlaintextBallots when publishing #205

### DIFF
--- a/src/electionguard/publish.py
+++ b/src/electionguard/publish.py
@@ -38,7 +38,7 @@ def publish(
     constants: ElectionConstants,
     devices: Iterable[EncryptionDevice],
     ciphertext_ballots: Iterable[CiphertextAcceptedBallot],
-    spoiled_ballots: Iterable[CiphertextAcceptedBallot],
+    spoiled_ballots: Iterable[PlaintextBallot],
     ciphertext_tally: PublishedCiphertextTally,
     plaintext_tally: PlaintextTally,
     coefficient_validation_sets: Iterable[CoefficientValidationSet] = None,

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -423,7 +423,11 @@ class TestEndToEndElection(TestCase):
             self.constants,
             [self.device],
             self.ballot_store.all(),
-            self.ciphertext_tally.spoiled_ballots.values(),
+            [
+                place
+                for spoiled in self.plaintext_tally.spoiled_ballots.values()
+                for place in spoiled.values()
+            ],
             publish_ciphertext_tally(self.ciphertext_tally),
             self.plaintext_tally,
             self.coefficient_validation_sets,


### PR DESCRIPTION
### Issue
Fixes #205

### Description
Type change for Spoiled Ballots arguments to be PlaintextBallots when publishing