### PR TITLE
Fix guardian = 0 in test_end_to_end_election

### DIFF
--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -167,7 +167,7 @@ class TestEndToEndElection(TestCase):
         # Setup Guardians
         for i in range(self.NUMBER_OF_GUARDIANS):
             self.guardians.append(
-                Guardian("guardian_" + str(i), i, self.NUMBER_OF_GUARDIANS, self.QUORUM)
+                Guardian("guardian_" + str(i), i + 1, self.NUMBER_OF_GUARDIANS, self.QUORUM)
             )
 
         # Setup Mediator


### PR DESCRIPTION
Fixes #335

Guardian sequence_order must be > 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/electionguard-python/336)
<!-- Reviewable:end -->
