### PR TITLE
Make discrete_log asynchronous

### DIFF
--- a/docs/4_Decrypt_Tally.md
+++ b/docs/4_Decrypt_Tally.md
@@ -1,22 +1,23 @@
 # Decryption
 
-At the conclusion of voting, all of the cast ballots are published in their encrypted form in the election record together with the proofs that the ballots are well-formed.  Additionally, all of the encryptions of each option are homomorphically-combined to form an encryption of the total number of times that each option was selected.  The homomorphically-combined encryptions are decrypted to generate the election tally.  Individual cast ballots are not decrypted.  Individual spoiled ballots are decrypted and the plaintext values are published along with the encrypted representations and the proofs.
+At the conclusion of voting, all of the cast ballots are published in their encrypted form in the election record together with the proofs that the ballots are well-formed. Additionally, all of the encryptions of each option are homomorphically-combined to form an encryption of the total number of times that each option was selected. The homomorphically-combined encryptions are decrypted to generate the election tally. Individual cast ballots are not decrypted. Individual spoiled ballots are decrypted and the plaintext values are published along with the encrypted representations and the proofs.
 
 In order to decrypt the homomorphically-combined encryption of each selection, each `Guardian` participating in the decryption must compute a specific `Decryption Share` of the decryption.
 
 It is preferable that all guardians be present for decryption, however in the event that guardians cannot be present, Electionguard includes a mechanism to decrypt with the `Quorum of Guardians`.
 
-During the [Key Ceremony](1_Key_Ceremony.md) a `Quorum of Guardians` is defined that represents the minimum number of guardians that must be present to decrypt the election.  If the decryption is to proceed with a `Quorum of Guardians` greater than or equal to the `Quorum` count, but less than the total number of guardians, then a subset of the `Available Guardians` must also each construct a `Partial Decryption Share` for the missing `Missing Guardian`, in addition to providing their own `Decryption Share`.
+During the [Key Ceremony](1_Key_Ceremony.md) a `Quorum of Guardians` is defined that represents the minimum number of guardians that must be present to decrypt the election. If the decryption is to proceed with a `Quorum of Guardians` greater than or equal to the `Quorum` count, but less than the total number of guardians, then a subset of the `Available Guardians` must also each construct a `Partial Decryption Share` for the missing `Missing Guardian`, in addition to providing their own `Decryption Share`.
 
-It is important to note that mathematically not every present guardian has to compute a `Partial Decryption Share` for every `Missing Guardian`.  Only the `Quorum Count` of guardians are necessary to construct `Partial Decryption Shares` in order to compensate for any Missing Guardian.  
+It is important to note that mathematically not every present guardian has to compute a `Partial Decryption Share` for every `Missing Guardian`. Only the `Quorum Count` of guardians are necessary to construct `Partial Decryption Shares` in order to compensate for any Missing Guardian.
 
-In this implementation, we take an approach that utilizes all Available Guardians to compensate for Missing Guardians.  When it is determined that guardians are missing, all available guardians each calculate a `Partial Decryption Share` for the missing guardian and publish the result.  A `Quorum of Guardians` count of available `Partial Decryption Shares` is randomly selected from the pool of available partial decryption shares for a given` Missing Guardian`.  If more than one guardian is missing, we randomly choose to ignore the `Partial Decryption Share` provided by one of the Available Guardians whose partial decryption share was chosen for the previous Missing Guardian, and randomly select again from the pool of available Partial Decryption Shares.  This ensures that all available guardians have the opportunity to participate in compensating for Missing Guardians.
+In this implementation, we take an approach that utilizes all Available Guardians to compensate for Missing Guardians. When it is determined that guardians are missing, all available guardians each calculate a `Partial Decryption Share` for the missing guardian and publish the result. A `Quorum of Guardians` count of available `Partial Decryption Shares` is randomly selected from the pool of available partial decryption shares for a given` Missing Guardian`. If more than one guardian is missing, we randomly choose to ignore the `Partial Decryption Share` provided by one of the Available Guardians whose partial decryption share was chosen for the previous Missing Guardian, and randomly select again from the pool of available Partial Decryption Shares. This ensures that all available guardians have the opportunity to participate in compensating for Missing Guardians.
 
 ## Glossary
+
 - **Guardian** A guardian of the election who holds the ability to partially decrypt the election results
 - **Decryption Share** A guardian's partial share of a decryption
-- **Encrypted Tally** The homomorphically-combined and encrypted representation of all selections made for each option on every contest in the election.  See [Ballot Box]() for more information.
-- **Key Ceremony** The process conducted at the beginning of the election to create the joint encryption context for encrypting ballots during the election.  See [Key Ceremony](1_Key_Ceremony.md) for more information.
+- **Encrypted Tally** The homomorphically-combined and encrypted representation of all selections made for each option on every contest in the election. See [Ballot Box]() for more information.
+- **Key Ceremony** The process conducted at the beginning of the election to create the joint encryption context for encrypting ballots during the election. See [Key Ceremony](1_Key_Ceremony.md) for more information.
 - **Quorum of Guardians** The minimum count (_threshold_) of guardians that must be present in order to successfully decrypt the election results.
 - **Available Guardian** A guardian that has announced as _present_ for the decryption phase
 - **Missing Guardian** A guardian who was configured during the `Key Ceremony` but who is not present for the decryption of the election results.
@@ -32,7 +33,7 @@ In this implementation, we take an approach that utilizes all Available Guardian
 
 3. If all guardians are present, the Decryption Shares are combined to generate a tally for each option on every contest
 
-### Decryption when some Guardians are Missing 
+### Decryption when some Guardians are Missing
 
 _warning: The functionality described in this segment is still a 🚧 Work In Progress_
 
@@ -47,7 +48,7 @@ When one or more of the Guardians are missing, any subset of the Guardians that 
 
 ## Challenged/Spoiled Ballots
 
-If a ballot is not to be included in the vote count, it is considered challenged, or [Spoiled](https://en.wikipedia.org/wiki/Spoilt_vote).  Every ballot spoiled in an election is individually verifiably decrypted in exactly the same way that the aggregate ballot of tallies is decrypted.  Since spoiled ballots are not included as part of the vote count, they are included in the Election Record with their plaintext values included along with the encrypted representations.
+If a ballot is not to be included in the vote count, it is considered challenged, or [Spoiled](https://en.wikipedia.org/wiki/Spoilt_vote). Every ballot spoiled in an election is individually verifiably decrypted in exactly the same way that the aggregate ballot of tallies is decrypted. Since spoiled ballots are not included as part of the vote count, they are included in the Election Record with their plaintext values included along with the encrypted representations.
 
 Spoiling ballots is an important part of the ElectionGuard process as it allows voters to explicitly generate challenge ballots that are verifiable as part of the Election Record.
 
@@ -60,7 +61,7 @@ Here is a simple example of how to execute the decryption process.
 internal_manifest: InternalManifest       # Load the election manifest
 context: CiphertextElectionContext          # Load the election encryption context
 encrypted_Tally: CiphertextTally            # Provide a tally from the previous step
-          
+
 available_guardians: List[Guardian]         # Provite the list of guardians who will participate
 missing_guardians: List[str]                # Provide a list of guardians who will not participate
 
@@ -77,7 +78,7 @@ for guardian in missing_guardians:
         break
 
 # Generate the plaintext tally
-plaintext_tally = mediator.get_plaintext_tally()
+plaintext_tally = await mediator.get_plaintext_tally()
 
 # The plaintext tally automatically includes the election tally and the spoiled ballots
 contest_tallies = plaintext_tally.contests
@@ -87,4 +88,4 @@ spoiled_ballots = plaintext_tally.spoiled_ballots
 
 ## Implementation Considerations
 
-In certain use cases where the `Key Ceremony` is not used, ballots and tallies can be decrypted directly using the secret key of the election.  See the [Tally Tests](https://github.com/microsoft/electionguard-python/tree/main/tests/test_tally.md) for an example of how to decrypt the tally using the secret key.
+In certain use cases where the `Key Ceremony` is not used, ballots and tallies can be decrypted directly using the secret key of the election. See the [Tally Tests](https://github.com/microsoft/electionguard-python/tree/main/tests/test_tally.md) for an example of how to decrypt the tally using the secret key.

--- a/src/electionguard/decrypt_with_secrets.py
+++ b/src/electionguard/decrypt_with_secrets.py
@@ -24,7 +24,7 @@ ELECTION_PUBLIC_KEY = ElementModP
 # The Methods in this file can be used to decrypt values if private keys or nonces are known
 
 
-def decrypt_selection_with_secret(
+async def decrypt_selection_with_secret(
     selection: CiphertextBallotSelection,
     description: SelectionDescription,
     public_key: ElementModP,
@@ -49,7 +49,7 @@ def decrypt_selection_with_secret(
         log_warning(f"selection: {selection.object_id} failed validity check")
         return None
 
-    plaintext_vote = selection.ciphertext.decrypt(secret_key)
+    plaintext_vote = await selection.ciphertext.decrypt(secret_key)
 
     # TODO: ISSUE #47: handle decryption of the extradata field if needed
 
@@ -60,7 +60,7 @@ def decrypt_selection_with_secret(
     )
 
 
-def decrypt_selection_with_nonce(
+async def decrypt_selection_with_nonce(
     selection: CiphertextBallotSelection,
     description: SelectionDescription,
     public_key: ElementModP,
@@ -104,7 +104,7 @@ def decrypt_selection_with_nonce(
         )
         return None
 
-    plaintext_vote = selection.ciphertext.decrypt_known_nonce(public_key, nonce)
+    plaintext_vote = await selection.ciphertext.decrypt_known_nonce(public_key, nonce)
 
     # TODO: ISSUE #35: encrypt/decrypt: handle decryption of the extradata field if needed
 
@@ -115,7 +115,7 @@ def decrypt_selection_with_nonce(
     )
 
 
-def decrypt_contest_with_secret(
+async def decrypt_contest_with_secret(
     contest: CiphertextBallotContest,
     description: ContestDescriptionWithPlaceholders,
     public_key: ElementModP,
@@ -145,7 +145,7 @@ def decrypt_contest_with_secret(
     plaintext_selections: List[PlaintextBallotSelection] = list()
     for selection in contest.ballot_selections:
         selection_description = description.selection_for(selection.object_id)
-        plaintext_selection = decrypt_selection_with_secret(
+        plaintext_selection = await decrypt_selection_with_secret(
             selection,
             get_optional(selection_description),
             public_key,
@@ -168,7 +168,7 @@ def decrypt_contest_with_secret(
     return PlaintextBallotContest(contest.object_id, plaintext_selections)
 
 
-def decrypt_contest_with_nonce(
+async def decrypt_contest_with_nonce(
     contest: CiphertextBallotContest,
     description: ContestDescriptionWithPlaceholders,
     public_key: ElementModP,
@@ -216,7 +216,7 @@ def decrypt_contest_with_nonce(
     plaintext_selections: List[PlaintextBallotSelection] = list()
     for selection in contest.ballot_selections:
         selection_description = description.selection_for(selection.object_id)
-        plaintext_selection = decrypt_selection_with_nonce(
+        plaintext_selection = await decrypt_selection_with_nonce(
             selection,
             get_optional(selection_description),
             public_key,
@@ -239,7 +239,7 @@ def decrypt_contest_with_nonce(
     return PlaintextBallotContest(contest.object_id, plaintext_selections)
 
 
-def decrypt_ballot_with_secret(
+async def decrypt_ballot_with_secret(
     ballot: CiphertextBallot,
     internal_manifest: InternalManifest,
     crypto_extended_base_hash: ElementModQ,
@@ -269,7 +269,7 @@ def decrypt_ballot_with_secret(
 
     for contest in ballot.contests:
         description = internal_manifest.contest_for(contest.object_id)
-        plaintext_contest = decrypt_contest_with_secret(
+        plaintext_contest = await decrypt_contest_with_secret(
             contest,
             get_optional(description),
             public_key,
@@ -289,7 +289,7 @@ def decrypt_ballot_with_secret(
     return PlaintextBallot(ballot.object_id, ballot.style_id, plaintext_contests)
 
 
-def decrypt_ballot_with_nonce(
+async def decrypt_ballot_with_nonce(
     ballot: CiphertextBallot,
     internal_manifest: InternalManifest,
     crypto_extended_base_hash: ElementModQ,
@@ -334,7 +334,7 @@ def decrypt_ballot_with_nonce(
 
     for contest in ballot.contests:
         description = internal_manifest.contest_for(contest.object_id)
-        plaintext_contest = decrypt_contest_with_nonce(
+        plaintext_contest = await decrypt_contest_with_nonce(
             contest,
             get_optional(description),
             public_key,

--- a/src/electionguard/decrypt_with_shares.py
+++ b/src/electionguard/decrypt_with_shares.py
@@ -28,7 +28,7 @@ ELECTION_PUBLIC_KEY = ElementModP
 # and the key ceremony is used to share secrets among a quorum of guardians
 
 
-def decrypt_tally(
+async def decrypt_tally(
     tally: CiphertextTally,
     shares: Dict[GUARDIAN_ID, DecryptionShare],
     crypto_extended_base_hash: ElementModQ,
@@ -44,7 +44,7 @@ def decrypt_tally(
     contests: Dict[CONTEST_ID, PlaintextTallyContest] = {}
 
     for contest in tally.contests.values():
-        plaintext_contest = decrypt_contest_with_decryption_shares(
+        plaintext_contest = await decrypt_contest_with_decryption_shares(
             CiphertextContest(
                 contest.object_id,
                 contest.description_hash,
@@ -61,7 +61,7 @@ def decrypt_tally(
     return PlaintextTally(tally.object_id, contests)
 
 
-def decrypt_ballot(
+async def decrypt_ballot(
     ballot: SubmittedBallot,
     shares: Dict[AVAILABLE_GUARDIAN_ID, DecryptionShare],
     crypto_extended_base_hash: ElementModQ,
@@ -77,7 +77,7 @@ def decrypt_ballot(
     contests: Dict[CONTEST_ID, PlaintextTallyContest] = {}
 
     for contest in ballot.contests:
-        plaintext_contest = decrypt_contest_with_decryption_shares(
+        plaintext_contest = await decrypt_contest_with_decryption_shares(
             CiphertextContest(
                 contest.object_id,
                 contest.description_hash,
@@ -94,7 +94,7 @@ def decrypt_ballot(
     return PlaintextTally(ballot.object_id, contests)
 
 
-def decrypt_contest_with_decryption_shares(
+async def decrypt_contest_with_decryption_shares(
     contest: CiphertextContest,
     shares: Dict[GUARDIAN_ID, DecryptionShare],
     crypto_extended_base_hash: ElementModQ,
@@ -111,7 +111,7 @@ def decrypt_contest_with_decryption_shares(
 
     for selection in contest.selections:
         tally_shares = get_shares_for_selection(selection.object_id, shares)
-        plaintext_selection = decrypt_selection_with_decryption_shares(
+        plaintext_selection = await decrypt_selection_with_decryption_shares(
             selection, tally_shares, crypto_extended_base_hash
         )
         if plaintext_selection is None:
@@ -127,7 +127,7 @@ def decrypt_contest_with_decryption_shares(
     return PlaintextTallyContest(contest.object_id, plaintext_selections)
 
 
-def decrypt_selection_with_decryption_shares(
+async def decrypt_selection_with_decryption_shares(
     selection: CiphertextSelection,
     shares: Dict[
         GUARDIAN_ID, Tuple[ELECTION_PUBLIC_KEY, CiphertextDecryptionSelection]
@@ -165,7 +165,7 @@ def decrypt_selection_with_decryption_shares(
 
     # Calculate 𝑀=𝐵⁄(∏𝑀𝑖) mod 𝑝.
     decrypted_value = div_p(selection.ciphertext.data, all_shares_product_M)
-    d_log = discrete_log(decrypted_value)
+    d_log = await discrete_log(decrypted_value)
     return PlaintextTallySelection(
         selection.object_id,
         d_log,

--- a/src/electionguard/decryption_mediator.py
+++ b/src/electionguard/decryption_mediator.py
@@ -249,7 +249,7 @@ class DecryptionMediator:
             # Add shares into ballot shares
             self._ballot_shares[ballot_id] = ballot_shares
 
-    def get_plaintext_tally(
+    async def get_plaintext_tally(
         self, ciphertext_tally: CiphertextTally
     ) -> Optional[PlaintextTally]:
         """
@@ -264,13 +264,13 @@ class DecryptionMediator:
         ):
             return None
 
-        return decrypt_tally(
+        return await decrypt_tally(
             ciphertext_tally,
             self._tally_shares,
             self._context.crypto_extended_base_hash,
         )
 
-    def get_plaintext_ballots(
+    async def get_plaintext_ballots(
         self, ciphertext_ballots: List[SubmittedBallot]
     ) -> Optional[Dict[BALLOT_ID, PlaintextTally]]:
         """
@@ -291,7 +291,7 @@ class DecryptionMediator:
             if not ballot_shares or not self._ready_to_decrypt(ballot_shares):
                 # Skip ballot if not ready to decrypt
                 continue
-            ballot = decrypt_ballot(
+            ballot = await decrypt_ballot(
                 ciphertext_ballot,
                 ballot_shares,
                 self._context.crypto_extended_base_hash,

--- a/src/electionguard/dlog.py
+++ b/src/electionguard/dlog.py
@@ -45,6 +45,9 @@ async def __discrete_log_internal(e: ElementModP) -> int:
         __dlog_lock = asyncio.Lock()
 
     async with __dlog_lock:
+        if e in __dlog_cache:
+            return __dlog_cache[e]
+
         g = int_to_p_unchecked(G)
         while e != __dlog_max_elem:
             __dlog_max_exp = __dlog_max_exp + 1

--- a/src/electionguard/dlog.py
+++ b/src/electionguard/dlog.py
@@ -13,7 +13,7 @@ __dlog_max_exp = 0
 __dlog_lock: Optional[asyncio.Lock] = None
 
 
-def discrete_log(e: ElementModP) -> int:
+async def discrete_log(e: ElementModP) -> int:
     """
     Computes the discrete log (base g, mod p) of the given element,
     with internal caching of results. Should run efficiently when called
@@ -30,7 +30,8 @@ def discrete_log(e: ElementModP) -> int:
     # no need for mutually exclusive access when reading from the cache
     if e in __dlog_cache:
         return __dlog_cache[e]
-    return asyncio.run(__discrete_log_internal(e))
+
+    return await __discrete_log_internal(e)
 
 
 async def __discrete_log_internal(e: ElementModP) -> int:

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -41,25 +41,27 @@ class ElGamalCiphertext(NamedTuple):
     data: ElementModP
     """encrypted data or beta"""
 
-    def decrypt_known_product(self, product: ElementModP) -> int:
+    async def decrypt_known_product(self, product: ElementModP) -> int:
         """
         Decrypts an ElGamal ciphertext with a "known product" (the blinding factor used in the encryption).
 
         :param product: The known product (blinding factor).
         :return: An exponentially encoded plaintext message.
         """
-        return discrete_log(mult_p(self.data, mult_inv_p(product)))
+        return await discrete_log(mult_p(self.data, mult_inv_p(product)))
 
-    def decrypt(self, secret_key: ElementModQ) -> int:
+    async def decrypt(self, secret_key: ElementModQ) -> int:
         """
         Decrypt an ElGamal ciphertext using a known ElGamal secret key.
 
         :param secret_key: The corresponding ElGamal secret key.
         :return: An exponentially encoded plaintext message.
         """
-        return self.decrypt_known_product(pow_p(self.pad, secret_key))
+        return await self.decrypt_known_product(pow_p(self.pad, secret_key))
 
-    def decrypt_known_nonce(self, public_key: ElementModP, nonce: ElementModQ) -> int:
+    async def decrypt_known_nonce(
+        self, public_key: ElementModP, nonce: ElementModQ
+    ) -> int:
         """
         Decrypt an ElGamal ciphertext using a known nonce and the ElGamal public key.
 
@@ -67,7 +69,7 @@ class ElGamalCiphertext(NamedTuple):
         :param nonce: The secret nonce used to create the ciphertext.
         :return: An exponentially encoded plaintext message.
         """
-        return self.decrypt_known_product(pow_p(public_key, nonce))
+        return await self.decrypt_known_product(pow_p(public_key, nonce))
 
     def partial_decrypt(self, secret_key: ElementModQ) -> ElementModP:
         """

--- a/src/electionguardtest/sample_generator.py
+++ b/src/electionguardtest/sample_generator.py
@@ -47,7 +47,7 @@ class ElectionSampleDataGenerator:
         self.ballot_factory = BallotFactory()
         self.encryption_device = self.election_factory.get_encryption_device()
 
-    def generate(
+    async def generate(
         self,
         number_of_ballots: int = DEFAULT_NUMBER_OF_BALLOTS,
         spoil_rate: int = DEFAULT_SPOIL_RATE,
@@ -133,8 +133,8 @@ class ElectionSampleDataGenerator:
                 spoiled_ciphertext_ballots.values(),
             )
 
-        plaintext_tally = mediator.get_plaintext_tally(ciphertext_tally)
-        plaintext_spoiled_ballots = mediator.get_plaintext_ballots(
+        plaintext_tally = await mediator.get_plaintext_tally(ciphertext_tally)
+        plaintext_spoiled_ballots = await mediator.get_plaintext_ballots(
             spoiled_ciphertext_ballots.values()
         )
 

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -4,6 +4,7 @@ from typing import Callable, Dict, List, Union
 from os import path
 from shutil import rmtree
 from unittest import TestCase
+import asyncio
 
 from random import randint
 from electionguard.type import BALLOT_ID
@@ -395,7 +396,9 @@ class TestEndToEndElection(TestCase):
 
         # Get the plaintext Tally
         self.plaintext_tally = get_optional(
-            self.decryption_mediator.get_plaintext_tally(self.ciphertext_tally)
+            asyncio.run(
+                self.decryption_mediator.get_plaintext_tally(self.ciphertext_tally)
+            )
         )
         self._assert_message(
             DecryptionMediator.get_plaintext_tally.__qualname__,
@@ -405,7 +408,9 @@ class TestEndToEndElection(TestCase):
 
         # Get the plaintext Spoiled Ballots
         self.plaintext_spoiled_ballots = get_optional(
-            self.decryption_mediator.get_plaintext_ballots(submitted_ballots_list)
+            asyncio.run(
+                self.decryption_mediator.get_plaintext_ballots(submitted_ballots_list)
+            )
         )
         self._assert_message(
             DecryptionMediator.get_plaintext_ballots.__qualname__,

--- a/tests/property/test_decrypt_with_secrets.py
+++ b/tests/property/test_decrypt_with_secrets.py
@@ -1,4 +1,6 @@
 import unittest
+import asyncio
+
 from copy import deepcopy
 from datetime import timedelta
 from random import Random
@@ -82,14 +84,20 @@ class TestDecryptWithSecrets(unittest.TestCase):
         )
         self.assertIsNotNone(subject)
 
-        result_from_key = decrypt_selection_with_secret(
-            subject, description, keypair.public_key, keypair.secret_key, ONE_MOD_Q
+        result_from_key = asyncio.run(
+            decrypt_selection_with_secret(
+                subject, description, keypair.public_key, keypair.secret_key, ONE_MOD_Q
+            )
         )
-        result_from_nonce = decrypt_selection_with_nonce(
-            subject, description, keypair.public_key, ONE_MOD_Q
+        result_from_nonce = asyncio.run(
+            decrypt_selection_with_nonce(
+                subject, description, keypair.public_key, ONE_MOD_Q
+            )
         )
-        result_from_nonce_seed = decrypt_selection_with_nonce(
-            subject, description, keypair.public_key, ONE_MOD_Q, nonce_seed
+        result_from_nonce_seed = asyncio.run(
+            decrypt_selection_with_nonce(
+                subject, description, keypair.public_key, ONE_MOD_Q, nonce_seed
+            )
         )
 
         # Assert
@@ -154,27 +162,35 @@ class TestDecryptWithSecrets(unittest.TestCase):
         )
         malformed_proof.proof = malformed_disjunctive
 
-        result_from_key_malformed_encryption = decrypt_selection_with_secret(
-            malformed_encryption,
-            description,
-            keypair.public_key,
-            keypair.secret_key,
-            ONE_MOD_Q,
+        result_from_key_malformed_encryption = asyncio.run(
+            decrypt_selection_with_secret(
+                malformed_encryption,
+                description,
+                keypair.public_key,
+                keypair.secret_key,
+                ONE_MOD_Q,
+            )
         )
 
-        result_from_key_malformed_proof = decrypt_selection_with_secret(
-            malformed_proof,
-            description,
-            keypair.public_key,
-            keypair.secret_key,
-            ONE_MOD_Q,
+        result_from_key_malformed_proof = asyncio.run(
+            decrypt_selection_with_secret(
+                malformed_proof,
+                description,
+                keypair.public_key,
+                keypair.secret_key,
+                ONE_MOD_Q,
+            )
         )
 
-        result_from_nonce_malformed_encryption = decrypt_selection_with_nonce(
-            malformed_encryption, description, keypair.public_key, ONE_MOD_Q
+        result_from_nonce_malformed_encryption = asyncio.run(
+            decrypt_selection_with_nonce(
+                malformed_encryption, description, keypair.public_key, ONE_MOD_Q
+            )
         )
-        result_from_nonce_malformed_proof = decrypt_selection_with_nonce(
-            malformed_proof, description, keypair.public_key, ONE_MOD_Q
+        result_from_nonce_malformed_proof = asyncio.run(
+            decrypt_selection_with_nonce(
+                malformed_proof, description, keypair.public_key, ONE_MOD_Q
+            )
         )
 
         # Assert
@@ -218,8 +234,10 @@ class TestDecryptWithSecrets(unittest.TestCase):
         # Tamper with the nonce by setting it to an arbitrary value
         subject.nonce = nonce_seed
 
-        result_from_nonce_seed = decrypt_selection_with_nonce(
-            subject, description, keypair.public_key, ONE_MOD_Q, nonce_seed
+        result_from_nonce_seed = asyncio.run(
+            decrypt_selection_with_nonce(
+                subject, description, keypair.public_key, ONE_MOD_Q, nonce_seed
+            )
         )
 
         # Assert
@@ -272,28 +290,34 @@ class TestDecryptWithSecrets(unittest.TestCase):
 
         # Decrypt the contest, but keep the placeholders
         # so we can verify the selection count matches as expected in the test
-        result_from_key = decrypt_contest_with_secret(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            keypair.secret_key,
-            ONE_MOD_Q,
-            remove_placeholders=False,
+        result_from_key = asyncio.run(
+            decrypt_contest_with_secret(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                keypair.secret_key,
+                ONE_MOD_Q,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            remove_placeholders=False,
+        result_from_nonce = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce_seed = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            nonce_seed,
-            remove_placeholders=False,
+        result_from_nonce_seed = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                nonce_seed,
+                remove_placeholders=False,
+            )
         )
 
         # Assert
@@ -433,20 +457,24 @@ class TestDecryptWithSecrets(unittest.TestCase):
         # tamper with the nonce
         subject.nonce = int_to_q_unchecked(1)
 
-        result_from_nonce = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            remove_placeholders=False,
+        result_from_nonce = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce_seed = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            nonce_seed,
-            remove_placeholders=False,
+        result_from_nonce_seed = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                nonce_seed,
+                remove_placeholders=False,
+            )
         )
 
         # Assert
@@ -458,28 +486,34 @@ class TestDecryptWithSecrets(unittest.TestCase):
             TWO_MOD_P, TWO_MOD_P
         )
 
-        result_from_key_tampered = decrypt_contest_with_secret(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            keypair.secret_key,
-            ONE_MOD_Q,
-            remove_placeholders=False,
+        result_from_key_tampered = asyncio.run(
+            decrypt_contest_with_secret(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                keypair.secret_key,
+                ONE_MOD_Q,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce_tampered = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            remove_placeholders=False,
+        result_from_nonce_tampered = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce_seed_tampered = decrypt_contest_with_nonce(
-            subject,
-            description_with_placeholders,
-            keypair.public_key,
-            ONE_MOD_Q,
-            nonce_seed,
-            remove_placeholders=False,
+        result_from_nonce_seed_tampered = asyncio.run(
+            decrypt_contest_with_nonce(
+                subject,
+                description_with_placeholders,
+                keypair.public_key,
+                ONE_MOD_Q,
+                nonce_seed,
+                remove_placeholders=False,
+            )
         )
 
         # Assert
@@ -517,28 +551,34 @@ class TestDecryptWithSecrets(unittest.TestCase):
         subject = operator.encrypt(data)
         self.assertIsNotNone(subject)
 
-        result_from_key = decrypt_ballot_with_secret(
-            subject,
-            internal_manifest,
-            context.crypto_extended_base_hash,
-            keypair.public_key,
-            keypair.secret_key,
-            remove_placeholders=False,
+        result_from_key = asyncio.run(
+            decrypt_ballot_with_secret(
+                subject,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                keypair.public_key,
+                keypair.secret_key,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce = decrypt_ballot_with_nonce(
-            subject,
-            internal_manifest,
-            context.crypto_extended_base_hash,
-            keypair.public_key,
-            remove_placeholders=False,
+        result_from_nonce = asyncio.run(
+            decrypt_ballot_with_nonce(
+                subject,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                keypair.public_key,
+                remove_placeholders=False,
+            )
         )
-        result_from_nonce_seed = decrypt_ballot_with_nonce(
-            subject,
-            internal_manifest,
-            context.crypto_extended_base_hash,
-            keypair.public_key,
-            subject.nonce,
-            remove_placeholders=False,
+        result_from_nonce_seed = asyncio.run(
+            decrypt_ballot_with_nonce(
+                subject,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                keypair.public_key,
+                subject.nonce,
+                remove_placeholders=False,
+            )
         )
 
         # Assert
@@ -684,20 +724,24 @@ class TestDecryptWithSecrets(unittest.TestCase):
 
         missing_nonce_value = None
 
-        result_from_nonce = decrypt_ballot_with_nonce(
-            subject,
-            internal_manifest,
-            context.crypto_extended_base_hash,
-            keypair.public_key,
+        result_from_nonce = asyncio.run(
+            decrypt_ballot_with_nonce(
+                subject,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                keypair.public_key,
+            )
         )
 
         # SUGGEST this test is the same as the one above
-        result_from_nonce_seed = decrypt_ballot_with_nonce(
-            subject,
-            internal_manifest,
-            context.crypto_extended_base_hash,
-            keypair.public_key,
-            missing_nonce_value,
+        result_from_nonce_seed = asyncio.run(
+            decrypt_ballot_with_nonce(
+                subject,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                keypair.public_key,
+                missing_nonce_value,
+            )
         )
 
         # Assert

--- a/tests/property/test_decryption_mediator.py
+++ b/tests/property/test_decryption_mediator.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-instance-attributes
 
 from unittest import TestCase
+import asyncio
 from datetime import timedelta
 from typing import Dict, List
 from random import randrange
@@ -209,8 +210,12 @@ class TestDecryptionMediator(TestCase):
         # Can only announce once
         self.assertEqual(len(mediator.get_available_guardians()), 1)
         # Cannot get plaintext tally or spoiled ballots without a quorum
-        self.assertIsNone(mediator.get_plaintext_tally(self.ciphertext_tally))
-        self.assertIsNone(mediator.get_plaintext_ballots(self.ciphertext_ballots))
+        self.assertIsNone(
+            asyncio.run(mediator.get_plaintext_tally(self.ciphertext_tally))
+        )
+        self.assertIsNone(
+            asyncio.run(mediator.get_plaintext_ballots(self.ciphertext_ballots))
+        )
 
     def test_get_plaintext_with_all_guardians_present(self):
         # Arrange
@@ -230,14 +235,20 @@ class TestDecryptionMediator(TestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
-        plaintext_ballots = mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        plaintext_tally = asyncio.run(
+            mediator.get_plaintext_tally(self.ciphertext_tally)
+        )
+        plaintext_ballots = asyncio.run(
+            mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        )
 
         # Convert to selections to check for the same tally
         selections = _convert_to_selections(plaintext_tally)
 
         # Verify we get the same tally back if we call again
-        another_plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
+        another_plaintext_tally = asyncio.run(
+            mediator.get_plaintext_tally(self.ciphertext_tally)
+        )
 
         # Assert
         self.assertIsNotNone(plaintext_tally)
@@ -272,14 +283,20 @@ class TestDecryptionMediator(TestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
-        plaintext_ballots = mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        plaintext_tally = asyncio.run(
+            mediator.get_plaintext_tally(self.ciphertext_tally)
+        )
+        plaintext_ballots = asyncio.run(
+            mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        )
 
         # Convert to selections to check for the same tally
         selections = _convert_to_selections(plaintext_tally)
 
         # Verify we get the same tally back if we call again
-        another_plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
+        another_plaintext_tally = asyncio.run(
+            mediator.get_plaintext_tally(self.ciphertext_tally)
+        )
 
         # Assert
         self.assertIsNotNone(plaintext_tally)
@@ -327,7 +344,7 @@ class TestDecryptionMediator(TestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(encrypted_tally)
+        plaintext_tally = asyncio.run(mediator.get_plaintext_tally(encrypted_tally))
         selections = _convert_to_selections(plaintext_tally)
 
         # Assert

--- a/tests/property/test_dlog.py
+++ b/tests/property/test_dlog.py
@@ -1,6 +1,7 @@
 import unittest
+import asyncio
 
-from hypothesis import given
+from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import integers
 
 from electionguard.dlog import discrete_log
@@ -40,17 +41,22 @@ class TestDLog(unittest.TestCase):
 
         self.assertEqual(exp, plaintext_again)
 
-    @given(integers(0, 1000))
+    @settings(
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    @given(
+        integers(0, 1000),
+    )
     def test_cached(self, exp: int):
         plaintext = get_optional(int_to_q(exp))
         exp_plaintext = g_pow_p(plaintext)
-        plaintext_again = discrete_log(exp_plaintext)
+        plaintext_again = asyncio.run(discrete_log(exp_plaintext))
 
         self.assertEqual(exp, plaintext_again)
 
     def test_cached_one(self):
         plaintext = int_to_q_unchecked(1)
         ciphertext = g_pow_p(plaintext)
-        plaintext_again = discrete_log(ciphertext)
+        plaintext_again = asyncio.run(discrete_log(ciphertext))
 
         self.assertEqual(1, plaintext_again)

--- a/tests/property/test_encrypt.py
+++ b/tests/property/test_encrypt.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 from copy import deepcopy
 from datetime import timedelta
 from random import Random
@@ -743,8 +744,10 @@ class TestEncrypt(unittest.TestCase):
 
             for selection in contest.ballot_selections:
                 # Since we know the nonce, we can decrypt the plaintext
-                representation = selection.ciphertext.decrypt_known_nonce(
-                    keypair.public_key, selection.nonce
+                representation = asyncio.run(
+                    selection.ciphertext.decrypt_known_nonce(
+                        keypair.public_key, selection.nonce
+                    )
                 )
 
                 # one could also decrypt with the secret key:

--- a/tests/property/test_encrypt_hypotheses.py
+++ b/tests/property/test_encrypt_hypotheses.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 from datetime import timedelta
 from typing import List, Dict
 
@@ -99,13 +100,15 @@ class TestElections(unittest.TestCase):
             self.assertEqual(num_contests, len(encrypted_ballot.contests))
 
             # decrypt the ballot with secret and verify it matches the plaintext
-            decrypted_ballot = decrypt_ballot_with_secret(
-                ballot=encrypted_ballot,
-                internal_manifest=internal_manifest,
-                crypto_extended_base_hash=context.crypto_extended_base_hash,
-                public_key=context.elgamal_public_key,
-                secret_key=secret_key,
-                remove_placeholders=True,
+            decrypted_ballot = asyncio.run(
+                decrypt_ballot_with_secret(
+                    ballot=encrypted_ballot,
+                    internal_manifest=internal_manifest,
+                    crypto_extended_base_hash=context.crypto_extended_base_hash,
+                    public_key=context.elgamal_public_key,
+                    secret_key=secret_key,
+                    remove_placeholders=True,
+                )
             )
             self.assertEqual(ballots[i], decrypted_ballot)
 
@@ -116,7 +119,9 @@ class TestElections(unittest.TestCase):
 
         decrypted_tallies = {}
         for object_id, encrypted_tally in encrypted_tallies.items():
-            decrypted_tallies[object_id] = encrypted_tally.decrypt(secret_key)
+            decrypted_tallies[object_id] = asyncio.run(
+                encrypted_tally.decrypt(secret_key)
+            )
 
         # loop through the contest descriptions and verify
         # the decrypted tallies match the plaintext tallies

--- a/tests/property/test_tally.py
+++ b/tests/property/test_tally.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import asyncio
 from datetime import timedelta
 from typing import Dict
 
@@ -70,7 +71,7 @@ class TestTally(TestCase):
         self.assertIsNotNone(result)
 
         # Assert
-        decrypted_tallies = self._decrypt_with_secret(result, secret_key)
+        decrypted_tallies = asyncio.run(self._decrypt_with_secret(result, secret_key))
         self.assertEqual(plaintext_tallies, decrypted_tallies)
 
     @settings(
@@ -115,7 +116,7 @@ class TestTally(TestCase):
         self.assertIsNotNone(tally)
 
         # Assert
-        decrypted_tallies = self._decrypt_with_secret(tally, secret_key)
+        decrypted_tallies = asyncio.run(self._decrypt_with_secret(tally, secret_key))
         self.assertCountEqual(plaintext_tallies, decrypted_tallies)
         for value in decrypted_tallies.values():
             self.assertEqual(0, value)
@@ -217,7 +218,7 @@ class TestTally(TestCase):
         self.assertFalse(tally.append(first_ballot))
 
     @staticmethod
-    def _decrypt_with_secret(
+    async def _decrypt_with_secret(
         tally: CiphertextTally, secret_key: ElementModQ
     ) -> Dict[str, int]:
         """
@@ -226,7 +227,7 @@ class TestTally(TestCase):
         plaintext_selections: Dict[str, int] = {}
         for _, contest in tally.contests.items():
             for object_id, selection in contest.selections.items():
-                plaintext_tally = selection.ciphertext.decrypt(secret_key)
+                plaintext_tally = await selection.ciphertext.decrypt(secret_key)
                 plaintext_selections[object_id] = plaintext_tally
 
         return plaintext_selections

--- a/tests/unit/test_decrypt_with_shares.py
+++ b/tests/unit/test_decrypt_with_shares.py
@@ -4,6 +4,7 @@
 
 from typing import Dict, List, Tuple
 from unittest import TestCase
+import asyncio
 
 from electionguard.ballot_box import BallotBox, BallotBoxState, get_ballots
 from electionguard.data_store import DataStore
@@ -194,8 +195,10 @@ class TestDecryptWithShares(TestCase):
         }
 
         # Act
-        result = decrypt_selection_with_decryption_shares(
-            first_selection, shares, self.context.crypto_extended_base_hash
+        result = asyncio.run(
+            decrypt_selection_with_decryption_shares(
+                first_selection, shares, self.context.crypto_extended_base_hash
+            )
         )
 
         # Assert
@@ -220,10 +223,12 @@ class TestDecryptWithShares(TestCase):
         }
 
         # act
-        result = decrypt_ballot(
-            encrypted_ballot,
-            shares,
-            self.context.crypto_extended_base_hash,
+        result = asyncio.run(
+            decrypt_ballot(
+                encrypted_ballot,
+                shares,
+                self.context.crypto_extended_base_hash,
+            )
         )
 
         # assert
@@ -287,10 +292,12 @@ class TestDecryptWithShares(TestCase):
         all_shares = {**available_shares, missing_guardian.id: reconstructed_share}
 
         # act
-        result = decrypt_ballot(
-            encrypted_ballot,
-            all_shares,
-            self.context.crypto_extended_base_hash,
+        result = asyncio.run(
+            decrypt_ballot(
+                encrypted_ballot,
+                all_shares,
+                self.context.crypto_extended_base_hash,
+            )
         )
 
         # assert

--- a/tests/unit/test_decryption.py
+++ b/tests/unit/test_decryption.py
@@ -4,6 +4,7 @@
 
 from typing import Dict, List
 from unittest import TestCase
+import asyncio
 from electionguard.ballot import SubmittedBallot
 
 from electionguard.ballot_box import BallotBox, BallotBoxState, get_ballots
@@ -390,23 +391,25 @@ class TestDecryption(TestCase):
         )
 
         # Decrypt the result
-        result = decrypt_selection_with_decryption_shares(
-            first_selection,
-            {
-                available_guardian_1.id: (
-                    available_guardian_1.share_election_public_key().key,
-                    share_0,
-                ),
-                available_guardian_2.id: (
-                    available_guardian_2.share_election_public_key().key,
-                    share_1,
-                ),
-                missing_guardian.id: (
-                    missing_guardian.share_election_public_key().key,
-                    share_2,
-                ),
-            },
-            self.context.crypto_extended_base_hash,
+        result = asyncio.run(
+            decrypt_selection_with_decryption_shares(
+                first_selection,
+                {
+                    available_guardian_1.id: (
+                        available_guardian_1.share_election_public_key().key,
+                        share_0,
+                    ),
+                    available_guardian_2.id: (
+                        available_guardian_2.share_election_public_key().key,
+                        share_1,
+                    ),
+                    missing_guardian.id: (
+                        missing_guardian.share_election_public_key().key,
+                        share_2,
+                    ),
+                },
+                self.context.crypto_extended_base_hash,
+            )
         )
 
         print(result)


### PR DESCRIPTION
### Issue
*Link your PR to an issue*

Fixes #393

### Description
Make the dlog async/await and propagate through the rest of the API's.  This is not an ideal solution for the long term but it unblocks the issue in the short term allowing the code to be called from inside a running event loop.

Further work to fix this correctly is tracked in #397 https://github.com/microsoft/electionguard-python/issues/397

### Testing
1. run the tests
