### PR TITLE
Crypto Hash using Sequence Order

### DIFF
--- a/data/ballot_in_simple.json
+++ b/data/ballot_in_simple.json
@@ -4,13 +4,16 @@
   "contests": [
     {
       "object_id": "justice-supreme-court",
+      "sequence_order": 0,
       "ballot_selections": [
         {
           "object_id": "john-adams-selection",
+          "sequence_order": 0,
           "vote": 1
         },
         {
           "object_id": "write-in-selection",
+          "sequence_order": 3,
           "vote": 1,
           "extended_data": {
             "value": "Susan B. Anthony",

--- a/data/plaintext_ballots_simple.json
+++ b/data/plaintext_ballots_simple.json
@@ -5,13 +5,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "vote": 1
+            "vote": 1,
+            "sequence_order": 0
           },
           {
             "object_id": "write-in-selection",
+            "sequence_order": 3,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -28,13 +31,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
+            "sequence_order": 0,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
+            "sequence_order": 3,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -51,13 +57,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
+            "sequence_order": 0,
             "vote": 1
           },
           {
             "object_id": "benjamin-franklin-selection",
+            "sequence_order": 2,
             "vote": 1
           }
         ]
@@ -70,13 +79,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
+            "sequence_order": 0,
             "vote": 1
           },
           {
             "object_id": "john-hancock-selection",
+            "sequence_order": 2,
             "vote": 1
           }
         ]
@@ -89,22 +101,27 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
+            "sequence_order": 0,
             "vote": 1
           },
           {
             "object_id": "john-hancock-selection",
+            "sequence_order": 2,
             "vote": 1
           }
         ]
       },
       {
         "object_id": "referendum-pineapple",
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
+            "sequence_order": 0,
             "vote": 1
           }
         ]
@@ -117,13 +134,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
+        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
+            "sequence_order": 0,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
+            "sequence_order": 3,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -134,9 +154,11 @@
       },
       {
         "object_id": "referendum-pineapple",
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-negative-selection",
+            "sequence_order": 1,
             "vote": 1
           }
         ]

--- a/data/plaintext_two_ballots_minimal.json
+++ b/data/plaintext_two_ballots_minimal.json
@@ -1,32 +1,36 @@
 [
-    {
-        "object_id": "external-ballot-id-1234",
-        "style_id": "ballot-style-01",
-        "contests": [
-            {
-                "object_id": "referendum-pineapple",
-                "ballot_selections": [
-                    {
-                        "object_id": "referendum-pineapple-affirmative-selection",
-                        "vote": 1
-                    }
-                ]
-            }
+  {
+    "object_id": "external-ballot-id-1234",
+    "style_id": "ballot-style-01",
+    "contests": [
+      {
+        "object_id": "referendum-pineapple",
+        "sequence_order": 0,
+        "ballot_selections": [
+          {
+            "object_id": "referendum-pineapple-affirmative-selection",
+            "sequence_order": 0,
+            "vote": 1
+          }
         ]
-    },
-    {
-        "object_id": "external-ballot-id-3457",
-        "style_id": "ballot-style-01",
-        "contests": [
-            {
-                "object_id": "referendum-pineapple",
-                "ballot_selections": [
-                    {
-                        "object_id": "referendum-pineapple-negative-selection",
-                        "vote": 1
-                    }
-                ]
-            }
+      }
+    ]
+  },
+  {
+    "object_id": "external-ballot-id-3457",
+    "style_id": "ballot-style-01",
+    "contests": [
+      {
+        "object_id": "referendum-pineapple",
+        "sequence_order": 1,
+        "ballot_selections": [
+          {
+            "object_id": "referendum-pineapple-negative-selection",
+            "sequence_order": 1,
+            "vote": 1
+          }
         ]
-    }
+      }
+    ]
+  }
 ]

--- a/data/plaintext_two_ballots_small.json
+++ b/data/plaintext_two_ballots_small.json
@@ -1,63 +1,74 @@
 [
-    {
-        "object_id": "external-ballot-id-2345",
-        "style_id": "franklin-county-ozark-schools",
-        "contests": [
-            {
-                "object_id": "referendum-pineapple",
-                "ballot_selections": [
-                    {
-                        "object_id": "referendum-pineapple-affirmative-selection",
-                        "vote": 1
-                    }
-                ]
-            },
-            {
-                "object_id": "congressional-race-01",
-                "ballot_selections": [
-                    {
-                        "object_id": "john-hancock-selection",
-                        "vote": 1
-                    }
-                ]
-            },
-            {
-                "object_id": "ozark-school-board-race",
-                "ballot_selections": [
-                    {
-                        "object_id": "samuel-adams-selection",
-                        "vote": 1
-                    },
-                    {
-                        "object_id": "thomas-jefferson-selection",
-                        "vote": 1
-                    }
-                ]
-            }
+  {
+    "object_id": "external-ballot-id-2345",
+    "style_id": "franklin-county-ozark-schools",
+    "contests": [
+      {
+        "object_id": "referendum-pineapple",
+        "sequence_order": 1,
+        "ballot_selections": [
+          {
+            "object_id": "referendum-pineapple-affirmative-selection",
+            "sequence_order": 0,
+            "vote": 1
+          }
         ]
-    },
-    {
-        "object_id": "external-ballot-id-9876",
-        "style_id": "franklin-county-no-schooldistrict",
-        "contests": [
-            {
-                "object_id": "referendum-pineapple",
-                "ballot_selections": [
-                    {
-                        "object_id": "referendum-pineapple-affirmative-selection",
-                        "vote": 1
-                    }
-                ]
-            },
-            {
-                "object_id": "congressional-race-01",
-                "ballot_selections": [
-                    {
-                        "object_id": "benjamin-franklin-selection",
-                        "vote": 1
-                    }
-                ]
-            }
+      },
+      {
+        "object_id": "congressional-race-01",
+        "sequence_order": 0,
+        "ballot_selections": [
+          {
+            "object_id": "john-hancock-selection",
+            "sequence_order": 0,
+            "vote": 1
+          }
         ]
-    }
+      },
+      {
+        "object_id": "ozark-school-board-race",
+        "sequence_order": 2,
+        "ballot_selections": [
+          {
+            "object_id": "samuel-adams-selection",
+            "sequence_order": 1,
+            "vote": 1
+          },
+          {
+            "object_id": "thomas-jefferson-selection",
+            "sequence_order": 2,
+            "vote": 1
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "object_id": "external-ballot-id-9876",
+    "style_id": "franklin-county-no-schooldistrict",
+    "contests": [
+      {
+        "object_id": "referendum-pineapple",
+        "sequence_order": 1,
+        "ballot_selections": [
+          {
+            "object_id": "referendum-pineapple-affirmative-selection",
+            "sequence_order": 0,
+            "vote": 1
+          }
+        ]
+      },
+      {
+        "object_id": "congressional-race-01",
+        "sequence_order": 0,
+        "ballot_selections": [
+          {
+            "object_id": "benjamin-franklin-selection",
+            "sequence_order": 1,
+            "vote": 1
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -546,7 +546,9 @@ def _ciphertext_ballot_context_crypto_hash(
         )
         return ZERO_MOD_Q
 
-    selection_hashes = [selection.crypto_hash for selection in ballot_selections]
+    selection_hashes = [
+        selection.crypto_hash for selection in sequence_order_sort(ballot_selections)
+    ]
 
     return hash_elems(object_id, encryption_seed, *selection_hashes)
 
@@ -910,7 +912,7 @@ def create_ballot_hash(
 ) -> ElementModQ:
     """Create the hash of the ballot contests"""
 
-    contest_hashes = [contest.crypto_hash for contest in contests]
+    contest_hashes = [contest.crypto_hash for contest in sequence_order_sort(contests)]
     return hash_elems(ballot_id, description_hash, *contest_hashes)
 
 
@@ -939,7 +941,7 @@ def make_ciphertext_submitted_ballot(
     if len(contests) == 0:
         log_warning("ciphertext ballot with no contests")
 
-    contest_hashes = [contest.crypto_hash for contest in contests]
+    contest_hashes = [contest.crypto_hash for contest in sequence_order_sort(contests)]
     contest_hash = hash_elems(object_id, manifest_hash, *contest_hashes)
 
     timestamp = to_ticks(datetime.utcnow()) if timestamp is None else timestamp

--- a/src/electionguard/decrypt_with_secrets.py
+++ b/src/electionguard/decrypt_with_secrets.py
@@ -55,6 +55,7 @@ def decrypt_selection_with_secret(
 
     return PlaintextBallotSelection(
         selection.object_id,
+        selection.sequence_order,
         plaintext_vote,
         selection.is_placeholder_selection,
     )
@@ -110,6 +111,7 @@ def decrypt_selection_with_nonce(
 
     return PlaintextBallotSelection(
         selection.object_id,
+        selection.sequence_order,
         plaintext_vote,
         selection.is_placeholder_selection,
     )
@@ -165,7 +167,9 @@ def decrypt_contest_with_secret(
             )
             return None
 
-    return PlaintextBallotContest(contest.object_id, plaintext_selections)
+    return PlaintextBallotContest(
+        contest.object_id, contest.sequence_order, plaintext_selections
+    )
 
 
 def decrypt_contest_with_nonce(
@@ -236,7 +240,9 @@ def decrypt_contest_with_nonce(
             )
             return None
 
-    return PlaintextBallotContest(contest.object_id, plaintext_selections)
+    return PlaintextBallotContest(
+        contest.object_id, contest.sequence_order, plaintext_selections
+    )
 
 
 def decrypt_ballot_with_secret(

--- a/src/electionguard/decrypt_with_shares.py
+++ b/src/electionguard/decrypt_with_shares.py
@@ -47,6 +47,7 @@ def decrypt_tally(
         plaintext_contest = decrypt_contest_with_decryption_shares(
             CiphertextContest(
                 contest.object_id,
+                contest.sequence_order,
                 contest.description_hash,
                 list(contest.selections.values()),
             ),
@@ -80,6 +81,7 @@ def decrypt_ballot(
         plaintext_contest = decrypt_contest_with_decryption_shares(
             CiphertextContest(
                 contest.object_id,
+                contest.sequence_order,
                 contest.description_hash,
                 contest.ballot_selections,
             ),

--- a/src/electionguard/decryption.py
+++ b/src/electionguard/decryption.py
@@ -67,6 +67,7 @@ def compute_decryption_share(
             guardian_keys,
             CiphertextContest(
                 contest.object_id,
+                contest.sequence_order,
                 contest.description_hash,
                 list(contest.selections.values()),
             ),
@@ -120,6 +121,7 @@ def compute_compensated_decryption_share(
             missing_guardian_backup,
             CiphertextContest(
                 contest.object_id,
+                contest.sequence_order,
                 contest.description_hash,
                 list(contest.selections.values()),
             ),
@@ -161,7 +163,10 @@ def compute_decryption_share_for_ballot(
         contest_share = compute_decryption_share_for_contest(
             guardian_keys,
             CiphertextContest(
-                contest.object_id, contest.description_hash, contest.ballot_selections
+                contest.object_id,
+                contest.sequence_order,
+                contest.description_hash,
+                contest.ballot_selections,
             ),
             context,
             scheduler,
@@ -211,7 +216,10 @@ def compute_compensated_decryption_share_for_ballot(
             missing_guardian_key,
             missing_guardian_backup,
             CiphertextContest(
-                contest.object_id, contest.description_hash, contest.ballot_selections
+                contest.object_id,
+                contest.sequence_order,
+                contest.description_hash,
+                contest.ballot_selections,
             ),
             context,
             decrypt,
@@ -563,6 +571,7 @@ def reconstruct_decryption_share(
             missing_guardian_key.owner_id,
             CiphertextContest(
                 contest.object_id,
+                contest.sequence_order,
                 contest.description_hash,
                 list(contest.selections.values()),
             ),
@@ -601,7 +610,10 @@ def reconstruct_decryption_share_for_ballot(
         contests[contest.object_id] = reconstruct_decryption_contest(
             missing_guardian_key.owner_id,
             CiphertextContest(
-                contest.object_id, contest.description_hash, contest.ballot_selections
+                contest.object_id,
+                contest.sequence_order,
+                contest.description_hash,
+                contest.ballot_selections,
             ),
             shares,
             lagrange_coefficients,

--- a/src/electionguard/election_object_base.py
+++ b/src/electionguard/election_object_base.py
@@ -1,4 +1,7 @@
+"""Base objects to derive other election objects."""
+
 from dataclasses import dataclass
+from typing import List, TypeVar
 
 
 @dataclass
@@ -6,3 +9,24 @@ class ElectionObjectBase:
     """A base object to derive other election objects identifiable by object_id."""
 
     object_id: str
+
+
+@dataclass
+class OrderedObjectBase(ElectionObjectBase):
+    """A ordered base object to derive other election objects."""
+
+    sequence_order: int
+    """
+    Used for ordering in a ballot to ensure various encryption primitives are deterministic.
+    The sequence order must be unique and should be representative of how the items are represented
+    on a template ballot in an external system.  The sequence order is not required to be in the order
+    in which they are displayed to a voter.  Any acceptable range of integer values may be provided.
+    """
+
+
+_Orderable_T = TypeVar("_Orderable_T", bound="OrderedObjectBase")
+
+
+def sequence_order_sort(unsorted: List[_Orderable_T]) -> List[_Orderable_T]:
+    """Sort by sequence order."""
+    return sorted(unsorted, key=lambda item: item.sequence_order)

--- a/src/electionguard/encrypt.py
+++ b/src/electionguard/encrypt.py
@@ -126,8 +126,9 @@ def selection_from(
 
     return PlaintextBallotSelection(
         description.object_id,
-        vote=1 if is_affirmative else 0,
-        is_placeholder_selection=is_placeholder,
+        description.sequence_order,
+        1 if is_affirmative else 0,
+        is_placeholder,
     )
 
 
@@ -145,7 +146,9 @@ def contest_from(description: ContestDescription) -> PlaintextBallotContest:
     for selection_description in description.ballot_selections:
         selections.append(selection_from(selection_description))
 
-    return PlaintextBallotContest(description.object_id, selections)
+    return PlaintextBallotContest(
+        description.object_id, description.sequence_order, selections
+    )
 
 
 def encrypt_selection(
@@ -200,15 +203,16 @@ def encrypt_selection(
 
     # Create the return object
     encrypted_selection = make_ciphertext_ballot_selection(
-        object_id=selection.object_id,
-        description_hash=selection_description_hash,
-        ciphertext=get_optional(elgamal_encryption),
-        elgamal_public_key=elgamal_public_key,
-        crypto_extended_base_hash=crypto_extended_base_hash,
-        proof_seed=disjunctive_chaum_pedersen_nonce,
-        selection_representation=selection_representation,
-        is_placeholder_selection=is_placeholder,
-        nonce=selection_nonce,
+        selection.object_id,
+        selection.sequence_order,
+        selection_description_hash,
+        get_optional(elgamal_encryption),
+        elgamal_public_key,
+        crypto_extended_base_hash,
+        disjunctive_chaum_pedersen_nonce,
+        selection_representation,
+        is_placeholder,
+        selection_nonce,
     )
 
     if encrypted_selection.proof is None:
@@ -366,13 +370,14 @@ def encrypt_contest(
 
     # Create the return object
     encrypted_contest = make_ciphertext_ballot_contest(
-        object_id=contest.object_id,
-        description_hash=contest_description_hash,
-        ballot_selections=encrypted_selections,
-        elgamal_public_key=elgamal_public_key,
-        crypto_extended_base_hash=crypto_extended_base_hash,
-        proof_seed=chaum_pedersen_nonce,
-        number_elected=contest_description.number_elected,
+        contest.object_id,
+        contest.sequence_order,
+        contest_description_hash,
+        encrypted_selections,
+        elgamal_public_key,
+        crypto_extended_base_hash,
+        chaum_pedersen_nonce,
+        contest_description.number_elected,
         nonce=contest_nonce,
     )
 

--- a/src/electionguard/manifest.py
+++ b/src/electionguard/manifest.py
@@ -4,7 +4,7 @@ from enum import Enum, unique
 from typing import cast, List, Optional, Set, Any
 
 from .ballot import _list_eq
-from .election_object_base import ElectionObjectBase
+from .election_object_base import ElectionObjectBase, OrderedObjectBase
 from .group import ElementModQ
 from .hash import CryptoHashable, hash_elems
 from .logs import log_warning, log_debug
@@ -275,7 +275,7 @@ class Candidate(ElectionObjectBase, CryptoHashable):
 
 
 @dataclass(eq=True, unsafe_hash=True)
-class SelectionDescription(ElectionObjectBase, CryptoHashable):
+class SelectionDescription(OrderedObjectBase, CryptoHashable):
     """
     Data entity for the ballot selections in a contest,
     for example linking candidates and parties to their vote counts.
@@ -290,13 +290,6 @@ class SelectionDescription(ElectionObjectBase, CryptoHashable):
     """
 
     candidate_id: str
-    sequence_order: int
-    """
-    Used for ordering selections in a contest to ensure various encryption primitives are deterministic.
-    The sequence order must be unique and should be representative of how the contests are represnted
-    on a "master" ballot in an external system.  The sequence order is not required to be in the order
-    in which they are displayed to a voter.  Any acceptable range of integer values may be provided.
-    """
 
     def crypto_hash(self) -> ElementModQ:
         """
@@ -309,7 +302,7 @@ class SelectionDescription(ElectionObjectBase, CryptoHashable):
 
 # pylint: disable=too-many-instance-attributes
 @dataclass(unsafe_hash=True)
-class ContestDescription(ElectionObjectBase, CryptoHashable):
+class ContestDescription(OrderedObjectBase, CryptoHashable):
     """
     Use this data entity for describing a contest and linking the contest
     to the associated candidates and parties.
@@ -322,13 +315,6 @@ class ContestDescription(ElectionObjectBase, CryptoHashable):
     """
 
     electoral_district_id: str
-    sequence_order: int
-    """
-    Used for ordering contests in a ballot to ensure various encryption primitives are deterministic.
-    The sequence order must be unique and should be representative of how the contests are represnted
-    on a "master" ballot in an external system.  The sequence order is not required to be in the order
-    in which they are displayed to a voter.  Any acceptable range of integer values may be provided.
-    """
 
     vote_variation: VoteVariationType
 
@@ -875,8 +861,8 @@ def generate_placeholder_selection_from(
     placeholder_object_id = f"{contest.object_id}-{use_sequence_id}"
     return SelectionDescription(
         f"{placeholder_object_id}-placeholder",
-        f"{placeholder_object_id}-candidate",
         use_sequence_id,
+        f"{placeholder_object_id}-candidate",
     )
 
 

--- a/src/electionguard/tally.py
+++ b/src/electionguard/tally.py
@@ -13,7 +13,7 @@ from .data_store import DataStore
 from .ballot_validator import ballot_is_valid_for_election
 from .decryption_share import CiphertextDecryptionSelection
 from .election import CiphertextElectionContext
-from .election_object_base import ElectionObjectBase
+from .election_object_base import ElectionObjectBase, OrderedObjectBase
 from .elgamal import ElGamalCiphertext, elgamal_add
 from .group import ElementModQ, ONE_MOD_P, ElementModP
 from .logs import log_warning
@@ -43,6 +43,9 @@ class CiphertextTallySelection(ElectionObjectBase, CiphertextSelection):
     a CiphertextTallySelection is a homomorphic accumulation of all of the
     CiphertextBallotSelection instances for a specific selection in an election.
     """
+
+    sequence_order: int
+    """Order of the selection."""
 
     description_hash: ElementModQ
     """
@@ -77,7 +80,7 @@ class PlaintextTallyContest(ElectionObjectBase):
 
 
 @dataclass
-class CiphertextTallyContest(ElectionObjectBase):
+class CiphertextTallyContest(OrderedObjectBase):
     """
     A CiphertextTallyContest is a container for associating a collection of CiphertextTallySelection
     to a specific ContestDescription
@@ -366,11 +369,16 @@ class CiphertextTally(ElectionObjectBase, Container, Sized):
             contest_selections: Dict[str, CiphertextTallySelection] = {}
             for selection in contest.ballot_selections:
                 contest_selections[selection.object_id] = CiphertextTallySelection(
-                    selection.object_id, selection.crypto_hash()
+                    selection.object_id,
+                    selection.sequence_order,
+                    selection.crypto_hash(),
                 )
 
             cast_collection[contest.object_id] = CiphertextTallyContest(
-                contest.object_id, contest.crypto_hash(), contest_selections
+                contest.object_id,
+                contest.sequence_order,
+                contest.crypto_hash(),
+                contest_selections,
             )
 
         return cast_collection

--- a/src/electionguardtest/ballot_factory.py
+++ b/src/electionguardtest/ballot_factory.py
@@ -87,7 +87,9 @@ class BallotFactory:
             elif bool(random.randint(0, 1)) == 1:
                 selections.append(selection_from(selection_description))
 
-        return PlaintextBallotContest(description.object_id, selections)
+        return PlaintextBallotContest(
+            description.object_id, description.sequence_order, selections
+        )
 
     def get_fake_ballot(
         self,

--- a/src/electionguardtest/election.py
+++ b/src/electionguardtest/election.py
@@ -355,7 +355,7 @@ def _candidate_to_selection_description(
     tell that they're related.
     """
     return SelectionDescription(
-        f"c-{candidate.object_id}", candidate.get_candidate_id(), sequence_order
+        f"c-{candidate.object_id}", sequence_order, candidate.get_candidate_id()
     )
 
 
@@ -617,7 +617,9 @@ def plaintext_voted_ballot(draw: _DrawType, internal_manifest: InternalManifest)
         ]
 
         voted_contests.append(
-            PlaintextBallotContest(contest.object_id, voted_selections)
+            PlaintextBallotContest(
+                contest.object_id, contest.sequence_order, voted_selections
+            )
         )
 
     return PlaintextBallot(str(draw(uuids())), ballot_style.object_id, voted_contests)

--- a/src/electionguardtest/election_factory.py
+++ b/src/electionguardtest/election_factory.py
@@ -139,9 +139,9 @@ class ElectionFactory:
         fake_referendum_ballot_selections = [
             # Referendum selections are simply a special case of `candidate` in the object model
             SelectionDescription(
-                "some-object-id-affirmative", "some-candidate-id-1", 0
+                "some-object-id-affirmative", 0, "some-candidate-id-1"
             ),
-            SelectionDescription("some-object-id-negative", "some-candidate-id-2", 1),
+            SelectionDescription("some-object-id-negative", 1, "some-candidate-id-2"),
         ]
 
         sequence_order = 0
@@ -149,8 +149,8 @@ class ElectionFactory:
         votes_allowed = 1
         fake_referendum_contest = ReferendumContestDescription(
             "some-referendum-contest-object-id",
-            "some-geopoltical-unit-id",
             sequence_order,
+            "some-geopoltical-unit-id",
             VoteVariationType.one_of_m,
             number_elected,
             votes_allowed,
@@ -160,13 +160,13 @@ class ElectionFactory:
 
         fake_candidate_ballot_selections = [
             SelectionDescription(
-                "some-object-id-candidate-1", "some-candidate-id-1", 0
+                "some-object-id-candidate-1", 0, "some-candidate-id-1"
             ),
             SelectionDescription(
-                "some-object-id-candidate-2", "some-candidate-id-2", 1
+                "some-object-id-candidate-2", 1, "some-candidate-id-2"
             ),
             SelectionDescription(
-                "some-object-id-candidate-3", "some-candidate-id-3", 2
+                "some-object-id-candidate-3", 2, "some-candidate-id-3"
             ),
         ]
 
@@ -175,8 +175,8 @@ class ElectionFactory:
         votes_allowed_2 = 2
         fake_candidate_contest = CandidateContestDescription(
             "some-candidate-contest-object-id",
-            "some-geopoltical-unit-id",
             sequence_order_2,
+            "some-geopoltical-unit-id",
             VoteVariationType.one_of_m,
             number_elected_2,
             votes_allowed_2,
@@ -272,7 +272,7 @@ def get_selection_description_well_formed(
 
     object_id = f"{candidate_id}-selection-{draw(ids)}"
 
-    return (object_id, SelectionDescription(object_id, candidate_id, sequence_order))
+    return (object_id, SelectionDescription(object_id, sequence_order, candidate_id))
 
 
 @composite
@@ -310,8 +310,8 @@ def get_contest_description_well_formed(
 
     contest_description = ContestDescription(
         object_id,
-        electoral_district_id,
         sequence_order,
+        electoral_district_id,
         VoteVariationType.n_of_m,
         number_elected,
         votes_allowed,

--- a/tests/property/test_encrypt.py
+++ b/tests/property/test_encrypt.py
@@ -69,7 +69,7 @@ class TestEncrypt(BaseTestCase):
         keypair = elgamal_keypair_from_secret(int_to_q(2))
         nonce = randbelow(get_small_prime())
         metadata = SelectionDescription(
-            "some-selection-object-id", "some-candidate-id", 1
+            "some-selection-object-id", 1, "some-candidate-id"
         )
         hash_context = metadata.crypto_hash()
 
@@ -94,7 +94,7 @@ class TestEncrypt(BaseTestCase):
         keypair = elgamal_keypair_from_secret(int_to_q(2))
         nonce = randbelow(get_small_prime())
         metadata = SelectionDescription(
-            "some-selection-object-id", "some-candidate-id", 1
+            "some-selection-object-id", 1, "some-candidate-id"
         )
         hash_context = metadata.crypto_hash()
 
@@ -241,21 +241,21 @@ class TestEncrypt(BaseTestCase):
         nonce = randbelow(get_small_prime())
         ballot_selections = [
             SelectionDescription(
-                "some-object-id-affirmative", "some-candidate-id-affirmative", 0
+                "some-object-id-affirmative", 0, "some-candidate-id-affirmative"
             ),
             SelectionDescription(
-                "some-object-id-negative", "some-candidate-id-negative", 1
+                "some-object-id-negative", 1, "some-candidate-id-negative"
             ),
         ]
         placeholder_selections = [
             SelectionDescription(
-                "some-object-id-placeholder", "some-candidate-id-placeholder", 2
+                "some-object-id-placeholder", 2, "some-candidate-id-placeholder"
             )
         ]
         metadata = ContestDescriptionWithPlaceholders(
             "some-contest-object-id",
-            "some-electoral-district-id",
             0,
+            "some-electoral-district-id",
             VoteVariationType.one_of_m,
             1,
             1,
@@ -445,15 +445,11 @@ class TestEncrypt(BaseTestCase):
             name="",
             ballot_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=0,
+                    "0@A.com-selection",
+                    0,
+                    "0@A.com",
                 ),
-                SelectionDescription(
-                    object_id="0@B.com-selection",
-                    candidate_id="0@B.com",
-                    sequence_order=1,
-                ),
+                SelectionDescription("0@B.com-selection", 1, "0@B.com"),
             ],
             ballot_title=None,
             ballot_subtitle=None,
@@ -499,15 +495,15 @@ class TestEncrypt(BaseTestCase):
             name="",
             ballot_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=0,
+                    "0@A.com-selection",
+                    0,
+                    "0@A.com",
                 ),
                 # Note the selection description is the same as the first sequence element
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=1,
+                    "0@A.com-selection",
+                    1,
+                    "0@A.com",
                 ),
             ],
         )

--- a/tests/property/test_encrypt_hypotheses.py
+++ b/tests/property/test_encrypt_hypotheses.py
@@ -101,12 +101,11 @@ class TestElections(BaseTestCase):
 
             # decrypt the ballot with secret and verify it matches the plaintext
             decrypted_ballot = decrypt_ballot_with_secret(
-                ballot=encrypted_ballot,
-                internal_manifest=internal_manifest,
-                crypto_extended_base_hash=context.crypto_extended_base_hash,
-                public_key=context.elgamal_public_key,
-                secret_key=secret_key,
-                remove_placeholders=True,
+                encrypted_ballot,
+                internal_manifest,
+                context.crypto_extended_base_hash,
+                context.elgamal_public_key,
+                secret_key,
             )
             self.assertEqual(ballots[i], decrypted_ballot)
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -95,23 +95,23 @@ class TestManifest(BaseTestCase):
             name="",
             ballot_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=0,
+                    "0@A.com-selection",
+                    0,
+                    "0@A.com",
                 ),
                 SelectionDescription(
-                    object_id="0@B.com-selection",
-                    candidate_id="0@B.com",
-                    sequence_order=1,
+                    "0@B.com-selection",
+                    1,
+                    "0@B.com",
                 ),
             ],
             ballot_title=None,
             ballot_subtitle=None,
             placeholder_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-contest-2-placeholder",
-                    candidate_id="0@A.com-contest-2-candidate",
-                    sequence_order=2,
+                    "0@A.com-contest-2-placeholder",
+                    2,
+                    "0@A.com-contest-2-candidate",
                 )
             ],
         )
@@ -130,24 +130,24 @@ class TestManifest(BaseTestCase):
             name="",
             ballot_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=0,
+                    "0@A.com-selection",
+                    0,
+                    "0@A.com",
                 ),
                 # simulate a bad selection description input
                 SelectionDescription(
-                    object_id="0@A.com-selection",
-                    candidate_id="0@A.com",
-                    sequence_order=1,
+                    "0@A.com-selection",
+                    1,
+                    "0@A.com",
                 ),
             ],
             ballot_title=None,
             ballot_subtitle=None,
             placeholder_selections=[
                 SelectionDescription(
-                    object_id="0@A.com-contest-2-placeholder",
-                    candidate_id="0@A.com-contest-2-candidate",
-                    sequence_order=2,
+                    "0@A.com-contest-2-placeholder",
+                    2,
+                    "0@A.com-contest-2-candidate",
                 )
             ],
         )


### PR DESCRIPTION
_🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository._

### Issue
*Link your PR to an issue*

Fixes #350 

### Description
The crypto hash did not have obvious problems but did not correctly ensure ordering. The item present to check for this was the sequence order. This resolves this problem by ensuring the ballot maintains the ordering allowing quick sorting. This is important to have on the ballot to ensure that without the manifest the ballot contests and selections can still be correctly sorted. This also helps solve equality problems that could present themselves and simplify things on the compact ballot. 

The approach was to add the sequence_order slowly into the ciphertext pieces and then allow this to ripple into the plaintext. A method was added to sort to ensure that the sort function was minimized. It currently exists only in a singular location. 

### Testing
The main tests to review are the tests around decryption and tally. This being said the existing test suite has coverage on this pull request. 
