### PR TITLE
✨ Add explicit export for Lagrange Coefficients

### DIFF
--- a/src/electionguard/decryption_mediator.py
+++ b/src/electionguard/decryption_mediator.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional
 
+from electionguard.group import ElementModQ
+
 from .ballot import SubmittedBallot
 from .decryption import (
     compute_lagrange_coefficients_for_guardians,
@@ -189,10 +191,13 @@ class DecryptionMediator:
             ] = share
             self._compensated_ballot_shares[ballot_id] = ballot_shares
 
-    def reconstruct_shares_for_tally(self, ciphertext_tally: CiphertextTally) -> None:
-        lagrange_coefficients = compute_lagrange_coefficients_for_guardians(
+    def get_lagrange_coefficients(self) -> Dict[GUARDIAN_ID, ElementModQ]:
+        return compute_lagrange_coefficients_for_guardians(
             list(self._available_guardians.values())
         )
+
+    def reconstruct_shares_for_tally(self, ciphertext_tally: CiphertextTally) -> None:
+        lagrange_coefficients = self.get_lagrange_coefficients()
         for (
             missing_guardian_id,
             missing_guardian_key,

--- a/src/electionguard/election_polynomial.py
+++ b/src/electionguard/election_polynomial.py
@@ -91,6 +91,16 @@ def compute_polynomial_coordinate(
     return computed_value
 
 
+@dataclass
+class LagrangeCoefficientsRecord:
+    """
+    Record for lagrange coefficients for specific coordinates, usually the guardian sequence order
+    to be used in the public election record.
+    """
+
+    coefficients: List[ElementModQ]
+
+
 # pylint: disable=unnecessary-comprehension
 def compute_lagrange_coefficient(coordinate: int, *degrees: int) -> ElementModQ:
     """

--- a/src/electionguardtest/export.py
+++ b/src/electionguardtest/export.py
@@ -13,6 +13,7 @@ from typing import Iterable
 
 from electionguard.ballot import PlaintextBallot, CiphertextBallot, SubmittedBallot
 from electionguard.constants import ElectionConstants
+from electionguard.election_polynomial import LagrangeCoefficientsRecord
 from electionguard.guardian import GuardianRecord, PrivateGuardianRecord
 from electionguard.election import CiphertextElectionContext
 from electionguard.encrypt import EncryptionDevice
@@ -25,6 +26,7 @@ RESULTS_DIR = "results"
 MANIFEST_FILE_NAME = "manifest"
 CONTEXT_FILE_NAME = "context"
 CONSTANTS_FILE_NAME = "constants"
+COEFFICIENTS_FILE_NAME = "coefficients"
 ENCRYPTED_TALLY_FILE_NAME = "encrypted_tally"
 TALLY_FILE_NAME = "tally"
 
@@ -46,6 +48,7 @@ def export(
     ciphertext_tally: PublishedCiphertextTally,
     plaintext_tally: PlaintextTally,
     guardian_records: Iterable[GuardianRecord],
+    lagrange_coefficients: LagrangeCoefficientsRecord,
     results_directory: str = RESULTS_DIR,
 ) -> None:
     """Export the data required to publish the election record as json."""
@@ -56,8 +59,8 @@ def export(
 
     to_file(manifest, MANIFEST_FILE_NAME, results_directory)
     to_file(context, CONTEXT_FILE_NAME, results_directory)
-
     to_file(constants, CONSTANTS_FILE_NAME, results_directory)
+    to_file(lagrange_coefficients, COEFFICIENTS_FILE_NAME, results_directory)
 
     for device in devices:
         to_file(device, DEVICE_PREFIX + str(device.device_id), devices_directory)


### PR DESCRIPTION


_🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository._

### Issue
*Link your PR to an issue*

Fixes #281 

### Description
- Add an explicit record for lagrange coefficients generated by the decryption mediator. This will now export as its own file and can be quickly exported from the mediator. This could also be used isolated in a functional way without a mediator. 

### Testing
New lines were added to end-to-end integration test. This is the only test that can properly showcase an export. 
