### PR TITLE
🧮 Utilize optimized encryption equations

### DIFF
--- a/src/electionguard/chaum_pedersen.py
+++ b/src/electionguard/chaum_pedersen.py
@@ -418,17 +418,17 @@ def make_disjunctive_chaum_pedersen_zero(
     beta = message.data
 
     # Pick three random numbers in Q.
-    c1, v1, u0 = Nonces(seed, "disjoint-chaum-pedersen-proof")[0:3]
+    c1, v, u0 = Nonces(seed, "disjoint-chaum-pedersen-proof")[0:3]
 
     # Compute the NIZKP
     a0 = g_pow_p(u0)
     b0 = pow_p(k, u0)
-    q_minus_c1 = negate_q(c1)
-    a1 = mult_p(g_pow_p(v1), pow_p(alpha, q_minus_c1))
-    b1 = mult_p(pow_p(k, v1), g_pow_p(c1), pow_p(beta, q_minus_c1))
+    a1 = g_pow_p(v)
+    b1 = mult_p(pow_p(k, v), g_pow_p(c1))
     c = hash_elems(q, alpha, beta, a0, b0, a1, b1)
     c0 = a_minus_b_q(c, c1)
     v0 = a_plus_bc_q(u0, c0, r)
+    v1 = a_plus_bc_q(v, c1, r)
 
     return DisjunctiveChaumPedersenProof(a0, b0, a1, b1, c0, c1, c, v0, v1)
 
@@ -454,16 +454,17 @@ def make_disjunctive_chaum_pedersen_one(
     beta = message.data
 
     # Pick three random numbers in Q.
-    c0, v0, u1 = Nonces(seed, "disjoint-chaum-pedersen-proof")[0:3]
+    w, v, u1 = Nonces(seed, "disjoint-chaum-pedersen-proof")[0:3]
 
     # Compute the NIZKP
-    q_minus_c0 = negate_q(c0)
-    a0 = mult_p(g_pow_p(v0), pow_p(alpha, q_minus_c0))
-    b0 = mult_p(pow_p(k, v0), pow_p(beta, q_minus_c0))
+    a0 = g_pow_p(v)
+    b0 = mult_p(pow_p(k, v), g_pow_p(w))
     a1 = g_pow_p(u1)
     b1 = pow_p(k, u1)
     c = hash_elems(q, alpha, beta, a0, b0, a1, b1)
-    c1 = a_minus_b_q(c, c0)
+    c0 = negate_q(w)
+    c1 = add_q(c, w)
+    v0 = a_plus_bc_q(v, c0, r)
     v1 = a_plus_bc_q(u1, c1, r)
 
     return DisjunctiveChaumPedersenProof(a0, b0, a1, b1, c0, c1, c, v0, v1)


### PR DESCRIPTION
### Issue

Fixes #411 

### Description
Changed the computation of the Chaum-Pederson proofs to more efficient versions saving two modular exponentiations per proof. Still computes the exact same proofs and verification stays the same.

(Note, there is a typo in the Word document that is attached to the issue: the alternative for the proof of an encryption of zero  needs to compute `v1 = (v + c1*R) mod q`.)

### Testing
Run Chaum-Pedersen tests.
