### PR TITLE
Fix super() call in ballot.py related to DeprecationWarning

### DIFF
--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -850,7 +850,7 @@ class SubmittedBallot(CiphertextBallot):
     def __eq__(self, other: Any) -> bool:
         return (
             isinstance(other, SubmittedBallot)
-            and super.__eq__(self, other)
+            and super().__eq__(other)
             and self.state == other.state
         )
 

--- a/src/electionguard/ballot_compact.py
+++ b/src/electionguard/ballot_compact.py
@@ -9,7 +9,7 @@ from .ballot import (
     PlaintextBallot,
     PlaintextBallotContest,
     PlaintextBallotSelection,
-    create_ballot_hash,
+    make_ciphertext_submitted_ballot,
 )
 from .ballot_box import BallotBoxState
 from .election import CiphertextElectionContext
@@ -97,11 +97,8 @@ def expand_compact_submitted_ballot(
             plaintext_ballot, internal_manifest, context, nonce_seed
         )
     )
-    crypto_hash = create_ballot_hash(
-        plaintext_ballot.object_id, internal_manifest.manifest_hash, contests
-    )
 
-    return SubmittedBallot(
+    return make_ciphertext_submitted_ballot(
         plaintext_ballot.object_id,
         plaintext_ballot.style_id,
         internal_manifest.manifest_hash,
@@ -109,8 +106,6 @@ def expand_compact_submitted_ballot(
         contests,
         compact_ballot.code,
         compact_ballot.timestamp,
-        crypto_hash,
-        compact_ballot.ballot_nonce,
         compact_ballot.ballot_box_state,
     )
 


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #488 
Fixes #491 

### Description

fixed super() call on __eq__ on line 853 of ballot.py, which were raising DeprecationWarning and NotImplemented.

### Testing
Run test_ballot_compact.py unit test. However, now it fails `line 91, in test_compact_submitted_ballot` apparently due to the nonce of submitted ballot (None) not matching the nonce of other (expanded ballot). I am submitting as a WIP. Please let me know what the tests are expected to do and the changes to the test that should be made. Can I force push any amendments or?

Thanks in advance.
