### PR TITLE
Dataclass incompatible: Fix fields in manifest contactInfo

### DIFF
--- a/src/electionguard_tools/strategies/election.py
+++ b/src/electionguard_tools/strategies/election.py
@@ -174,6 +174,14 @@ def reporting_unit_types(draw: _DrawType):
     n = draw(sampled_from(ReportingUnitType))
     return ReportingUnitType(n)
 
+@composite
+def annotated_emails(draw: _DrawType):
+    """
+       Generates a `Email` object with an arbitrary two-letter string as annotation and an
+       email format string as value.
+       :param draw: Hidden argument, used by Hypothesis.
+       """
+    return AnnotatedString(draw(two_letter_codes()), draw(emails()))
 
 @composite
 def contact_infos(draw: _DrawType):
@@ -181,8 +189,7 @@ def contact_infos(draw: _DrawType):
     Generates a `ContactInformation` object.
     :param draw: Hidden argument, used by Hypothesis.
     """
-    # empty lists for email and phone, for now
-    return ContactInformation(None, draw(annotated_emails()), None, draw(human_names()))
+    return ContactInformation(None, draw(lists(annotated_emails(), min_size=1, max_size=3)), None, draw(human_names()))
 
 
 @composite

--- a/src/electionguard_tools/strategies/election.py
+++ b/src/electionguard_tools/strategies/election.py
@@ -174,14 +174,16 @@ def reporting_unit_types(draw: _DrawType):
     n = draw(sampled_from(ReportingUnitType))
     return ReportingUnitType(n)
 
+
 @composite
 def annotated_emails(draw: _DrawType):
     """
-       Generates a `Email` object with an arbitrary two-letter string as annotation and an
-       email format string as value.
-       :param draw: Hidden argument, used by Hypothesis.
-       """
+    Generates a `Email` object with an arbitrary two-letter string as annotation and an
+    email format string as value.
+    :param draw: Hidden argument, used by Hypothesis.
+    """
     return AnnotatedString(draw(two_letter_codes()), draw(emails()))
+
 
 @composite
 def contact_infos(draw: _DrawType):
@@ -189,7 +191,12 @@ def contact_infos(draw: _DrawType):
     Generates a `ContactInformation` object.
     :param draw: Hidden argument, used by Hypothesis.
     """
-    return ContactInformation(None, draw(lists(annotated_emails(), min_size=1, max_size=3)), None, draw(human_names()))
+    return ContactInformation(
+        None,
+        draw(lists(annotated_emails(), min_size=1, max_size=3)),
+        None,
+        draw(human_names()),
+    )
 
 
 @composite


### PR DESCRIPTION
The initial manifest creation draws a String using emails() methods from hypothesis strategies, but it requires a list of annotated string. I added a annotated_emails method to draw a two_letter_code for annotation and a email-format string for value. 

### Issue

Fixes #495 

### Description
Generate a list of annotated string for email field in contact info. 
### Testing
make test