### PR TITLE
Fix equality of InternalManifests constructed from same Manifest

### DIFF
--- a/src/electionguard_tools/strategies/election.py
+++ b/src/electionguard_tools/strategies/election.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from functools import reduce
 from random import Random
 from typing import TypeVar, Callable, List, Optional, Tuple
@@ -623,7 +624,7 @@ def plaintext_voted_ballot(draw: _DrawType, internal_manifest: InternalManifest)
     for contest in contests:
         assert contest.is_valid(), "every contest needs to be valid"
         n = contest.number_elected  # we need exactly this many 1's, and the rest 0's
-        ballot_selections = contest.ballot_selections
+        ballot_selections = deepcopy(contest.ballot_selections)
         assert len(ballot_selections) >= n
 
         random = Random(draw(integers()))

--- a/tests/property/test_verify.py
+++ b/tests/property/test_verify.py
@@ -16,7 +16,6 @@ from electionguard.elgamal import ElGamalKeyPair
 from electionguard.encrypt import EncryptionMediator, encrypt_ballot
 from electionguard.key_ceremony import CeremonyDetails
 from electionguard.key_ceremony_mediator import KeyCeremonyMediator
-from electionguard.manifest import InternalManifest
 from electionguard.tally import tally_ballots
 from electionguard.type import GuardianId
 from electionguard.utils import get_optional
@@ -121,7 +120,7 @@ class TestVerify(BaseTestCase):
         self.assertTrue(verification.verified)
 
     @settings(
-        deadline=timedelta(milliseconds=2000),
+        deadline=timedelta(milliseconds=10000),
         suppress_health_check=[HealthCheck.too_slow],
         max_examples=10,
         # disabling the "shrink" phase, because it runs very slowly
@@ -132,12 +131,11 @@ class TestVerify(BaseTestCase):
         # Arrange
         (
             manifest,
-            _internal_manifest,
+            internal_manifest,
             ballots,
             _secret_key,
             context,
         ) = election_details
-        internal_manifest = InternalManifest(manifest)
 
         # encrypt each ballot
         store = DataStore()


### PR DESCRIPTION
### Issue

Fixes #501 

### Description
The cause of inequality of InternalManifests constructed from same Manifest was
https://github.com/microsoft/electionguard-python/blob/db1287d66c8aabf70a9d338bf6c249578906b3df/src/electionguard_tools/strategies/election.py#L630

Since lists are call by reference in python, shuffling `ballot_selections` affects `contest`. This changes the hash of `Contests` and creates a difference in `manifest_hash` for the `InternalManifest`.

Creating a copy of `ballot_selections` fixes this issue and made improvements to the test that uses this method.
