### PR TITLE
Allow specifying sample to use when running the generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # C extensions
 *.so
 
+data/0.95.0/
+
 # Distribution / packaging
 .Python
 build/
@@ -146,3 +148,6 @@ election_private_data.zip
 
 # VS Code
 .vscode/settings.json
+sample-data.zip
+
+results/

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ environment:
 	poetry config virtualenvs.in-project true 
 	poetry install
 	@echo 🚨 Be sure to add poetry to PATH
-	ifeq ($(OS), Windows)
-		choco install wget
-		choco install unzip
-	endif
+ifeq ($(OS), Windows)
+	choco install wget
+	choco install unzip
+endif
 	wget https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
 	unzip -o sample-data.zip
 	unzip sample-data.zip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all openssl-fix install install-gmp install-gmp-mac install-gmp-linux install-gmp-windows install-mkdocs auto-lint validate test test-example bench coverage coverage-html coverage-xml coverage-erase generate-sample-data
+.PHONY: all environment openssl-fix install install-gmp install-gmp-mac install-gmp-linux install-gmp-windows install-mkdocs auto-lint validate test test-example bench coverage coverage-html coverage-xml coverage-erase generate-sample-data
 
 CODE_COVERAGE ?= 90
 OS ?= $(shell python -c 'import platform; print(platform.system())')
@@ -19,7 +19,12 @@ environment:
 	poetry config virtualenvs.in-project true 
 	poetry install
 	@echo 🚨 Be sure to add poetry to PATH
-	wget -O sample-data.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
+	ifeq ($(OS), Windows)
+		choco install wget
+		choco install unzip
+	endif
+	wget https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
+	unzip -o sample-data.zip
 	unzip sample-data.zip
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ environment:
 	poetry config virtualenvs.in-project true 
 	poetry install
 	@echo 🚨 Be sure to add poetry to PATH
+	wget -O sample-data.zip https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
+	unzip sample-data.zip
 
 install:
 	@echo 🔧 INSTALL
@@ -181,7 +183,7 @@ dependency-graph-ci:
 
 # Sample Data
 generate-sample-data:
-	poetry run python3 src/electionguard_tools/scripts/sample_generator.py -n $(SAMPLE_BALLOT_COUNT) -s $(SAMPLE_BALLOT_SPOIL_RATE)
+	poetry run python3 src/electionguard_tools/scripts/sample_generator.py -m "hamilton-general" -n $(SAMPLE_BALLOT_COUNT) -s $(SAMPLE_BALLOT_SPOIL_RATE)
 
 # Publish
 publish:

--- a/src/electionguard_tools/__init__.py
+++ b/src/electionguard_tools/__init__.py
@@ -68,6 +68,8 @@ from electionguard_tools.helpers import (
 )
 from electionguard_tools.scripts import (
     DEFAULT_NUMBER_OF_BALLOTS,
+    DEFAULT_SAMPLE_MANIFEST,
+    DEFAULT_SPEC_VERSION,
     DEFAULT_SPOIL_RATE,
     DEFAULT_USE_ALL_GUARDIANS,
     DEFAULT_USE_PRIVATE_DATA,
@@ -121,6 +123,8 @@ __all__ = [
     "CONTEXT_FILE_NAME",
     "CiphertextElectionsTupleType",
     "DEFAULT_NUMBER_OF_BALLOTS",
+    "DEFAULT_SAMPLE_MANIFEST",
+    "DEFAULT_SPEC_VERSION",
     "DEFAULT_SPOIL_RATE",
     "DEFAULT_USE_ALL_GUARDIANS",
     "DEFAULT_USE_PRIVATE_DATA",

--- a/src/electionguard_tools/factories/election_factory.py
+++ b/src/electionguard_tools/factories/election_factory.py
@@ -84,6 +84,16 @@ class ElectionFactory:
         return self._get_manifest_from_file(self.simple_election_manifest_file_name)
 
     @staticmethod
+    def get_manifest_from_file(spec_version: str, sample_manifest: str) -> Manifest:
+        """Get simple manifest from json file."""
+        return from_file_to_dataclass(
+            Manifest,
+            os.path.join(
+                data, spec_version, "sample", sample_manifest, "manifest.json"
+            ),
+        )
+
+    @staticmethod
     def get_hamilton_manifest_from_file() -> Manifest:
         """Get Hamilton County manifest from json file."""
         return from_file_to_dataclass(
@@ -93,15 +103,15 @@ class ElectionFactory:
             ),
         )
 
-    def get_hamilton_manifest_with_encryption_context(
-        self,
+    def get_sample_manifest_with_encryption_context(
+        self, spec_version: str, sample_manifest: str
     ) -> Tuple[AllPublicElectionData, AllPrivateElectionData]:
         """Get hamilton manifest and context"""
         guardians: List[Guardian] = []
         guardian_records: List[GuardianRecord] = []
 
         # Configure the election builder
-        manifest = self.get_hamilton_manifest_from_file()
+        manifest = self.get_manifest_from_file(spec_version, sample_manifest)
         builder = ElectionBuilder(NUMBER_OF_GUARDIANS, QUORUM, manifest)
 
         # Run the Key Ceremony

--- a/src/electionguard_tools/scripts/__init__.py
+++ b/src/electionguard_tools/scripts/__init__.py
@@ -2,6 +2,8 @@ from electionguard_tools.scripts import sample_generator
 
 from electionguard_tools.scripts.sample_generator import (
     DEFAULT_NUMBER_OF_BALLOTS,
+    DEFAULT_SAMPLE_MANIFEST,
+    DEFAULT_SPEC_VERSION,
     DEFAULT_SPOIL_RATE,
     DEFAULT_USE_ALL_GUARDIANS,
     DEFAULT_USE_PRIVATE_DATA,
@@ -10,6 +12,8 @@ from electionguard_tools.scripts.sample_generator import (
 
 __all__ = [
     "DEFAULT_NUMBER_OF_BALLOTS",
+    "DEFAULT_SAMPLE_MANIFEST",
+    "DEFAULT_SPEC_VERSION",
     "DEFAULT_SPOIL_RATE",
     "DEFAULT_USE_ALL_GUARDIANS",
     "DEFAULT_USE_PRIVATE_DATA",

--- a/src/electionguard_tools/scripts/sample_generator.py
+++ b/src/electionguard_tools/scripts/sample_generator.py
@@ -65,7 +65,7 @@ class ElectionSampleDataGenerator:
         use_all_guardians: bool = DEFAULT_USE_ALL_GUARDIANS,
         use_private_data: bool = DEFAULT_USE_PRIVATE_DATA,
         spec_version: str = DEFAULT_SPEC_VERSION,
-        sample_manifest: str = DEFAULT_SAMPLE_MANIFEST
+        sample_manifest: str = DEFAULT_SAMPLE_MANIFEST,
     ):
         """
         Generate the sample data set
@@ -80,7 +80,9 @@ class ElectionSampleDataGenerator:
         (
             manifest,
             private_data,
-        ) = self.election_factory.get_sample_manifest_with_encryption_context(spec_version, sample_manifest)
+        ) = self.election_factory.get_sample_manifest_with_encryption_context(
+            spec_version, sample_manifest
+        )
         plaintext_ballots = (
             self.ballot_factory.generate_fake_plaintext_ballots_for_election(
                 manifest.internal_manifest, number_of_ballots
@@ -164,7 +166,9 @@ class ElectionSampleDataGenerator:
                 ciphertext_tally.publish(),
                 plaintext_tally,
                 manifest.guardians,
-                LagrangeCoefficientsRecord(list(mediator.get_lagrange_coefficients().values()))
+                LagrangeCoefficientsRecord(
+                    list(mediator.get_lagrange_coefficients().values())
+                ),
             )
 
             if use_private_data:
@@ -203,7 +207,7 @@ if __name__ == "__main__":
         default=DEFAULT_SAMPLE_MANIFEST,
         type=str,
         help="The manifest to use to generate sample data.",
-        choices=["full", "hamilton-general", "minimal", "small"]
+        choices=["full", "hamilton-general", "minimal", "small"],
     )
     parser.add_argument(
         "-n",
@@ -241,10 +245,15 @@ if __name__ == "__main__":
         default=DEFAULT_SPEC_VERSION,
         type=str,
         help="The spec version to use.",
-        choices=[DEFAULT_SPEC_VERSION]
+        choices=[DEFAULT_SPEC_VERSION],
     )
     args = parser.parse_args()
 
     ElectionSampleDataGenerator().generate(
-        args.number_of_ballots, args.spoil_rate, args.all_guardians, args.private_data, args.version, args.manifest
+        args.number_of_ballots,
+        args.spoil_rate,
+        args.all_guardians,
+        args.private_data,
+        args.version,
+        args.manifest,
     )

--- a/src/electionguard_tools/scripts/sample_generator.py
+++ b/src/electionguard_tools/scripts/sample_generator.py
@@ -11,6 +11,7 @@ from electionguard.ballot import (
 from electionguard.data_store import DataStore
 from electionguard.ballot_box import BallotBox, get_ballots
 from electionguard.decryption_mediator import DecryptionMediator
+from electionguard.election_polynomial import LagrangeCoefficientsRecord
 from electionguard.encrypt import (
     EncryptionDevice,
     EncryptionMediator,
@@ -36,6 +37,8 @@ DEFAULT_NUMBER_OF_BALLOTS = 5
 DEFAULT_SPOIL_RATE = 50
 DEFAULT_USE_ALL_GUARDIANS = False
 DEFAULT_USE_PRIVATE_DATA = False
+DEFAULT_SPEC_VERSION = "0.95.0"
+DEFAULT_SAMPLE_MANIFEST = "hamilton-general"
 
 
 class ElectionSampleDataGenerator:
@@ -61,6 +64,8 @@ class ElectionSampleDataGenerator:
         spoil_rate: int = DEFAULT_SPOIL_RATE,
         use_all_guardians: bool = DEFAULT_USE_ALL_GUARDIANS,
         use_private_data: bool = DEFAULT_USE_PRIVATE_DATA,
+        spec_version: str = DEFAULT_SPEC_VERSION,
+        sample_manifest: str = DEFAULT_SAMPLE_MANIFEST
     ):
         """
         Generate the sample data set
@@ -71,10 +76,11 @@ class ElectionSampleDataGenerator:
         rmtree(PRIVATE_DATA_DIR, ignore_errors=True)
 
         # Configure the election
+        # TODO: pass the spec version and the manifest name in
         (
             manifest,
             private_data,
-        ) = self.election_factory.get_hamilton_manifest_with_encryption_context()
+        ) = self.election_factory.get_sample_manifest_with_encryption_context(spec_version, sample_manifest)
         plaintext_ballots = (
             self.ballot_factory.generate_fake_plaintext_ballots_for_election(
                 manifest.internal_manifest, number_of_ballots
@@ -158,6 +164,7 @@ class ElectionSampleDataGenerator:
                 ciphertext_tally.publish(),
                 plaintext_tally,
                 manifest.guardians,
+                LagrangeCoefficientsRecord(list(mediator.get_lagrange_coefficients().values()))
             )
 
             if use_private_data:
@@ -187,6 +194,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate sample ballot data",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-m",
+        "--manifest",
+        metavar="<manifest>",
+        default=DEFAULT_SAMPLE_MANIFEST,
+        type=str,
+        help="The manifest to use to generate sample data.",
+        choices=["full", "hamilton-general", "minimal", "small"]
     )
     parser.add_argument(
         "-n",
@@ -218,8 +235,16 @@ if __name__ == "__main__":
         action="store_true",
         help="Include private data when generating.",
     )
+    parser.add_argument(
+        "-v",
+        "--version",
+        default=DEFAULT_SPEC_VERSION,
+        type=str,
+        help="The spec version to use.",
+        choices=[DEFAULT_SPEC_VERSION]
+    )
     args = parser.parse_args()
 
     ElectionSampleDataGenerator().generate(
-        args.number_of_ballots, args.spoil_rate, args.all_guardians, args.private_data
+        args.number_of_ballots, args.spoil_rate, args.all_guardians, args.private_data, args.version, args.manifest
     )


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #200

### Description
Add CLI params to the sample generation process to define a spec version and the sample set to use. when setting up the environment, pull down the sample data from the existing spec release from the `electionguard` spec repo.

This PR satisfies the requirement of making the sample generator configurable, however due to ongoing serialization changes, only the `hamilton-general` sample can actually be run at this time.

### Testing
1. `make environment`
2. `make generate-sample-data`

Expect: sample data is output correctly to the `/results` folder.
