### PR TITLE
✅ Ensure all python commands reference Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: all environment openssl-fix install install-gmp install-gmp-mac install-gmp-linux install-gmp-windows install-mkdocs auto-lint validate test test-example bench coverage coverage-html coverage-xml coverage-erase generate-sample-data
 
 CODE_COVERAGE ?= 90
-OS ?= $(shell python -c 'import platform; print(platform.system())')
+OS ?= $(shell python3 -c 'import platform; print(platform.system())')
 ifeq ($(OS), Linux)
-PKG_MGR ?= $(shell python -c 'import subprocess as sub; print(next(filter(None, (sub.getstatusoutput(f"command -v {pm}")[0] == 0 and pm for pm in ["apt-get", "pacman"])), "undefined"))')
+PKG_MGR ?= $(shell python3 -c 'import subprocess as sub; print(next(filter(None, (sub.getstatusoutput(f"command -v {pm}")[0] == 0 and pm for pm in ["apt-get", "pacman"])), "undefined"))')
 endif
-IS_64_BIT ?= $(shell python -c 'from sys import maxsize; print(maxsize > 2**32)')
+IS_64_BIT ?= $(shell python3 -c 'from sys import maxsize; print(maxsize > 2**32)')
 SAMPLE_BALLOT_COUNT ?= 5
 SAMPLE_BALLOT_SPOIL_RATE ?= 50
 
@@ -14,7 +14,7 @@ all: environment install build validate auto-lint coverage
 environment:
 	@echo 🔧 ENVIRONMENT SETUP
 	make install-gmp
-	python -m pip install -U pip
+	python3 -m pip install -U pip
 	pip3 install 'poetry==1.1.10'
 	poetry config virtualenvs.in-project true 
 	poetry install
@@ -111,7 +111,7 @@ auto-lint:
 	
 validate: 
 	@echo ✅ VALIDATE
-	@poetry run python -c 'import electionguard; print(electionguard.__package__ + " successfully imported")'
+	@poetry run python3 -c 'import electionguard; print(electionguard.__package__ + " successfully imported")'
 
 # Test
 unit-tests:


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #515 

### Description
Change all commands to reference Python 3 specifically. This is to simplify issues in MacOS where the user has to specify in their environment that `python` refers to Python 3 instead of the default Python 2. 

### Testing
Run any of the commands. This should happen by default by the CI
