### PR TITLE
♻️  Add GuardianId to LagrangeCoefficientRecord

### DIFF
--- a/src/electionguard/election_polynomial.py
+++ b/src/electionguard/election_polynomial.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 
 from .elgamal import ElGamalKeyPair
 from .group import (
@@ -17,6 +17,7 @@ from .group import (
     ZERO_MOD_Q,
 )
 from .schnorr import make_schnorr_proof, SchnorrProof
+from .type import GuardianId
 
 SecretCoefficient = ElementModQ  # Secret coefficient of election polynomial
 PublicCommitment = ElementModP  # Public commitment of election polynomial
@@ -112,7 +113,7 @@ class LagrangeCoefficientsRecord:
     to be used in the public election record.
     """
 
-    coefficients: List[ElementModQ]
+    coefficients: Dict[GuardianId, ElementModQ]
 
 
 # pylint: disable=unnecessary-comprehension

--- a/src/electionguard_tools/scripts/sample_generator.py
+++ b/src/electionguard_tools/scripts/sample_generator.py
@@ -165,9 +165,7 @@ class ElectionSampleDataGenerator:
                 ciphertext_tally.publish(),
                 plaintext_tally,
                 manifest.guardians,
-                LagrangeCoefficientsRecord(
-                    list(mediator.get_lagrange_coefficients().values())
-                ),
+                LagrangeCoefficientsRecord(mediator.get_lagrange_coefficients()),
             )
 
             if use_private_data:

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -403,7 +403,7 @@ class TestEndToEndElection(BaseTestCase):
             )
 
         self.lagrange_coefficients = LagrangeCoefficientsRecord(
-            list(self.decryption_mediator.get_lagrange_coefficients().values())
+            self.decryption_mediator.get_lagrange_coefficients()
         )
 
         # Get the plaintext Tally


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #520 

### Description
Change LagrangeCoefficients to stay a dictionary on output. This actually reduces some code complexity and quickly allows the guardian id to exist for the LagrangeCoefficients.

Sample data will have to regenerated following this. An issue will be made in `electionguard`

### Testing
The integration test is the best place for this to be caught. 