### PR TITLE
🐞 CiphertextSelection Equality due to Pydantic

### DIFF
--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Any, Iterable, Optional
+
 
 from .discrete_log import DiscreteLog
 from .group import (
@@ -42,6 +43,11 @@ class ElGamalCiphertext:
 
     data: ElementModP
     """encrypted data or beta"""
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, ElGamalCiphertext):
+            return self.pad == other.pad and self.data == other.data
+        return False
 
     def decrypt_known_product(self, product: ElementModP) -> int:
         """

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -587,6 +587,13 @@ class TestEndToEndElection(BaseTestCase):
                     submitted_ballots_directory,
                 ),
             )
+            self.assertTrue(
+                ballot_from_file.is_valid_encryption(
+                    self.internal_manifest.manifest_hash,
+                    self.context.elgamal_public_key,
+                    self.context.crypto_extended_base_hash,
+                )
+            )
             self.assertEqualAsDicts(ballot, ballot_from_file)
 
         for spoiled_ballot in self.plaintext_spoiled_ballots.values():


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #547 

### Description
Pydantic causes confusion between the classes. A direct solution would be relying on exclusively pydantic set of dataclasses. This causes issues due to BaseElement. Took a more direct solution is to override the equality and enforce primarily comparing the objects at the low level. 

Test added to prevent future issues around this section.*

### Testing
The integration tests performs a new test for this that checks for this error. 
