### PR TITLE
Fix bug

### DIFF
--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -1,5 +1,5 @@
-from pydantic.dataclasses import dataclass
 from typing import Any, Iterable, Optional, Union
+from pydantic.dataclasses import dataclass
 
 
 from .discrete_log import DiscreteLog

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass as basedataclass
 from typing import Any, Iterable, Optional, Union
-from pydantic.dataclasses import dataclass
+from pydantic.dataclasses import dataclass as pydanticdataclass
 
 
 from .discrete_log import DiscreteLog
@@ -27,19 +28,17 @@ _MAC_KEY_SIZE = 256
 _BLOCK_SIZE = 32
 
 
-@dataclass
+@pydanticdataclass
+@basedataclass
 class ElGamalKeyPair:
     """A tuple of an ElGamal secret key and public key."""
-
-    def __init__(self, secret_key: ElGamalSecretKey, public_key: ElGamalPublicKey):
-        self.secret_key = secret_key
-        self.public_key = public_key
 
     secret_key: ElGamalSecretKey
     public_key: ElGamalPublicKey
 
 
-@dataclass
+@pydanticdataclass
+@basedataclass
 class ElGamalCiphertext:
     """
     An "exponential ElGamal ciphertext" (i.e., with the plaintext in the exponent to allow for
@@ -52,10 +51,6 @@ class ElGamalCiphertext:
 
     data: ElementModP
     """encrypted data or beta"""
-
-    def __init__(self, pad: ElementModP, data: ElementModP):
-        self.pad = pad
-        self.data = data
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ElGamalCiphertext):
@@ -110,7 +105,8 @@ class ElGamalCiphertext:
         return hash_elems(self.pad, self.data)
 
 
-@dataclass
+@pydanticdataclass
+@basedataclass
 class HashedElGamalCiphertext:
     """
     A hashed version of ElGamal Ciphertext with less size restrictions.
@@ -126,11 +122,6 @@ class HashedElGamalCiphertext:
 
     mac: ElementModQ
     """message authentication code for hmac"""
-
-    def __init__(self, pad: ElementModP, data: bytes, mac: ElementModQ):
-        self.pad = pad
-        self.data = data
-        self.mac = mac
 
     def decrypt(
         self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ
@@ -296,8 +287,8 @@ def elgamal_add(*ciphertexts: ElGamalCiphertext) -> ElGamalCiphertext:
 
     result = ciphertexts[0]
     for c in ciphertexts[1:]:
-        result = ElGamalCiphertext(
-            mult_p(result.pad, c.pad), mult_p(result.data, c.data)
-        )
+        pad: ElementModP = mult_p(result.pad, c.pad)
+        data: ElementModP = mult_p(result.data, c.data)
+        result = ElGamalCiphertext(pad, data)
 
     return result

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 from typing import Any, Iterable, Optional, Union
 
 

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -31,6 +31,10 @@ _BLOCK_SIZE = 32
 class ElGamalKeyPair:
     """A tuple of an ElGamal secret key and public key."""
 
+    def __init__(self, secret_key: ElGamalSecretKey, public_key: ElGamalPublicKey):
+        self.secret_key = secret_key
+        self.public_key = public_key
+
     secret_key: ElGamalSecretKey
     public_key: ElGamalPublicKey
 
@@ -48,6 +52,10 @@ class ElGamalCiphertext:
 
     data: ElementModP
     """encrypted data or beta"""
+
+    def __init__(self, pad: ElementModP, data: ElementModP):
+        self.pad = pad
+        self.data = data
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, ElGamalCiphertext):
@@ -118,6 +126,11 @@ class HashedElGamalCiphertext:
 
     mac: ElementModQ
     """message authentication code for hmac"""
+
+    def __init__(self, pad: ElementModP, data: bytes, mac: ElementModQ):
+        self.pad = pad
+        self.data = data
+        self.mac = mac
 
     def decrypt(
         self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ


### PR DESCRIPTION
### Issue

Fixes #595 

### Description
It used to be the case that if you deserialize an object that has a property of type ElGamalCiphertext (e.g. SubmittedBallot) and then try to send it through a method that uses Scheduler.schedule (e.g. CiphertextTally.batch_append), then you get the following error: _pickle.PicklingError: Can't pickle <class 'pydantic.dataclasses._Pydantic_ElGamalCiphertext_94140943706128'>: it's not the same object as pydantic.dataclasses._Pydantic_ElGamalCiphertext_94140943706128.  The error was because the elgamal.py class was using the wrong dataclass attribute.  This fixes it.

### Testing

Generally speaking something like this, although I had difficulty getting the unit test to pass because I kept getting an OverflowError.  If I can get this test to pass I'll include it with this PR.

```
from typing import List
from electionguard.scheduler import Scheduler
from electionguard.serialize import from_file
from electionguard.ballot import SubmittedBallot
from tests.base_test_case import BaseTestCase


class TestElGamal(BaseTestCase):
    """Tests related to the ElGamal object"""

    def accumulate(self, ballot) -> SubmittedBallot:
        return ballot

    def schedule(self, submitted_ballots: List[SubmittedBallot]):
        with Scheduler() as scheduler:
            ballots = [(b) for b in submitted_ballots]
            return scheduler.schedule(
                self.accumulate,
                ballots,
            )

    def test_elgamal_deserialize_and_schedule(self) -> None:
        ballot = from_file(SubmittedBallot, "tests/unit/data/submitted_ballot.json")
        self.schedule([ballot])
```