### PR TITLE
📂 #623 Fix e2e to accept a directory for ballots

### DIFF
--- a/src/electionguard_cli/e2e/e2e_command.py
+++ b/src/electionguard_cli/e2e/e2e_command.py
@@ -34,9 +34,9 @@ from .e2e_publish_step import E2ePublishStep
 )
 @click.option(
     "--ballots",
-    prompt="Ballots file",
-    help="The location of a file that contains plaintext ballots.",
-    type=click.File(),
+    prompt="Ballots file or directory",
+    help="The location of a file or directory that contains plaintext ballots.",
+    type=click.Path(exists=True, dir_okay=True, file_okay=True),
 )
 @click.option(
     "--spoil-id",
@@ -68,7 +68,7 @@ def E2eCommand(
     guardian_count: int,
     quorum: int,
     manifest: TextIOWrapper,
-    ballots: TextIOWrapper,
+    ballots: str,
     spoil_id: str,
     output_record: str,
     output_keys: str,

--- a/src/electionguard_cli/e2e/e2e_input_retrieval_step.py
+++ b/src/electionguard_cli/e2e/e2e_input_retrieval_step.py
@@ -1,12 +1,13 @@
 from io import TextIOWrapper
 from typing import List
+from os.path import isfile, isdir, join
+from os import listdir
+from click import echo
 
 from electionguard.ballot import PlaintextBallot
 from electionguard.key_ceremony import CeremonyDetails
 from electionguard.manifest import Manifest
-from electionguard.serialize import (
-    from_list_in_file_wrapper,
-)
+from electionguard.serialize import from_list_in_file, from_file
 from electionguard_tools.helpers.key_ceremony_orchestrator import (
     KeyCeremonyOrchestrator,
 )
@@ -25,7 +26,7 @@ class E2eInputRetrievalStep(InputRetrievalStepBase):
         guardian_count: int,
         quorum: int,
         manifest_file: TextIOWrapper,
-        ballots_file: TextIOWrapper,
+        ballots_path: str,
         spoil_id: str,
         output_record: str,
         output_keys: str,
@@ -35,7 +36,7 @@ class E2eInputRetrievalStep(InputRetrievalStepBase):
             CeremonyDetails(guardian_count, quorum)
         )
         manifest: Manifest = self._get_manifest(manifest_file)
-        ballots = E2eInputRetrievalStep._get_ballots(ballots_file)
+        ballots = E2eInputRetrievalStep._get_ballots(ballots_path)
         self.print_value("Guardians", guardian_count)
         self.print_value("Quorum", quorum)
         return E2eInputs(
@@ -50,8 +51,18 @@ class E2eInputRetrievalStep(InputRetrievalStepBase):
         )
 
     @staticmethod
-    def _get_ballots(ballots_file: TextIOWrapper) -> List[PlaintextBallot]:
-        ballots: List[PlaintextBallot] = from_list_in_file_wrapper(
-            PlaintextBallot, ballots_file
+    def _get_ballots(ballots_path: str) -> List[PlaintextBallot]:
+        if isfile(ballots_path):
+            return from_list_in_file(PlaintextBallot, ballots_path)
+        if isdir(ballots_path):
+            files = listdir(ballots_path)
+            return [E2eInputRetrievalStep._get_ballot(ballots_path, f) for f in files]
+        raise ValueError(
+            f"{ballots_path} is neither a valid file nor a valid directory"
         )
-        return ballots
+
+    @staticmethod
+    def _get_ballot(ballots_dir: str, filename: str) -> PlaintextBallot:
+        full_file = join(ballots_dir, filename)
+        echo(f"importing {filename}")
+        return from_file(PlaintextBallot, full_file)


### PR DESCRIPTION
### Issue

Fixes #623 

### Description
Updates the `--ballots` parameter to accept either a file or a directory to pull ballots from.

### Testing
Try something like `poetry run eg e2e --guardian-count=2 --quorum=2 --manifest=../data/manifest.json --ballots=../data/plaintextballots --output-record="./election_record.zip"` where ../data/plaintextballots contains files with ballots