### PR TITLE
Updated sequence_order data in plaintext_ballots file

### DIFF
--- a/data/plaintext_ballots_simple.json
+++ b/data/plaintext_ballots_simple.json
@@ -5,16 +5,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
             "vote": 1,
-            "sequence_order": 0
+            "sequence_order": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 3,
+            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -31,16 +31,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 3,
+            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -57,11 +57,11 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           },
           {
@@ -79,11 +79,11 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           },
           {
@@ -101,11 +101,11 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           },
           {
@@ -117,11 +117,11 @@
       },
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 1,
+        "sequence_order": 2,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           }
         ]
@@ -134,16 +134,16 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 0,
+        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 0,
+            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 3,
+            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -154,7 +154,7 @@
       },
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 1,
+        "sequence_order": 2,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-negative-selection",


### PR DESCRIPTION
Fixes #624 

### Description
To rephrase what is described in the issue, sequence_order fields in https://github.com/microsoft/electionguard-python/blob/main/data/plaintext_ballots_simple.json were disorganized, so they have now been changed to start at one and increment by one for each sibling in the json structure.

### Testing
The changes are very minor and testing and linting passed. I'm pretty new to all of this so I don't know what else to say about how to test these changes.