### PR TITLE
🐛 Import guardians in all files in a folder not in a file

### DIFF
--- a/src/electionguard_cli/import_ballots/import_ballots_command.py
+++ b/src/electionguard_cli/import_ballots/import_ballots_command.py
@@ -1,5 +1,6 @@
 from io import TextIOWrapper
 import click
+from ordered_set import T
 
 from .import_ballots_publish_step import ImportBallotsPublishStep
 from .import_ballots_input_retrieval_step import ImportBallotsInputRetrievalStep
@@ -33,7 +34,7 @@ from ..cli_steps.tally_step import TallyStep
     prompt="Guardian keys file",
     help="The location of a json file with all guardians's private key data. "
     + "This corresponds to the output-keys parameter of the e2e command.",
-    type=click.Path(exists=True, dir_okay=False, file_okay=True, resolve_path=True),
+    type=click.Path(exists=True, dir_okay=True, file_okay=False, resolve_path=True),
 )
 @click.option(
     "--encryption-device",

--- a/src/electionguard_cli/import_ballots/import_ballots_command.py
+++ b/src/electionguard_cli/import_ballots/import_ballots_command.py
@@ -1,6 +1,5 @@
 from io import TextIOWrapper
 import click
-from ordered_set import T
 
 from .import_ballots_publish_step import ImportBallotsPublishStep
 from .import_ballots_input_retrieval_step import ImportBallotsInputRetrievalStep

--- a/src/electionguard_cli/import_ballots/import_ballots_input_retrieval_step.py
+++ b/src/electionguard_cli/import_ballots/import_ballots_input_retrieval_step.py
@@ -1,5 +1,7 @@
 from typing import List
 from io import TextIOWrapper
+from os import listdir
+from os.path import isfile, isdir, join
 
 from electionguard import CiphertextElectionContext
 from electionguard.ballot import SubmittedBallot
@@ -63,12 +65,21 @@ class ImportBallotsInputRetrievalStep(InputRetrievalStepBase):
 
     @staticmethod
     def _get_guardians_from_keys(
-        guardian_keys: str, context: CiphertextElectionContext
+        guardian_keys_dir: str, context: CiphertextElectionContext
     ) -> List[Guardian]:
-        guardian_private_records = from_list_in_file(
-            PrivateGuardianRecord, guardian_keys
-        )
+
+        files = listdir(guardian_keys_dir)
         return [
-            Guardian.from_private_record(g, context.number_of_guardians, context.quorum)
-            for g in guardian_private_records
+            ImportBallotsInputRetrievalStep._get_guardian(guardian_keys_dir, f, context)
+            for f in files
         ]
+
+    @staticmethod
+    def _get_guardian(
+        guardian_dir: str, filename: str, context: CiphertextElectionContext
+    ) -> Guardian:
+        full_file = join(guardian_dir, filename)
+        private_record = from_file(PrivateGuardianRecord, full_file)
+        return Guardian.from_private_record(
+            private_record, context.number_of_guardians, context.quorum
+        )

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -37,7 +37,7 @@ class OutputSetupFilesStep(OutputStepBase):
         constants = get_constants()
         self._export_file("Constants", constants, setup_inputs.out, CONSTANTS_FILE_NAME)
 
-    def _export_manifest(self, setup_inputs: Manifest) -> None:
+    def _export_manifest(self, setup_inputs: SetupInputs) -> None:
         self._export_file(
             "Manifest",
             setup_inputs.manifest,

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -1,11 +1,13 @@
 from os.path import join
 from electionguard.election import CiphertextElectionContext
+from electionguard.manifest import Manifest
 from electionguard.serialize import to_file
 from electionguard.constants import get_constants
 from electionguard_tools.helpers.export import (
     CONSTANTS_FILE_NAME,
     CONTEXT_FILE_NAME,
     GUARDIAN_PREFIX,
+    MANIFEST_FILE_NAME,
 )
 
 from .setup_inputs import SetupInputs
@@ -22,6 +24,7 @@ class OutputSetupFilesStep(OutputStepBase):
         self.print_header("Generating Output")
         self._export_context(setup_inputs, build_election_results.context)
         self._export_constants(setup_inputs)
+        self._export_manifest(setup_inputs)
         self._export_guardian_records(setup_inputs)
         self._export_guardian_private_keys(setup_inputs)
 
@@ -32,8 +35,14 @@ class OutputSetupFilesStep(OutputStepBase):
 
     def _export_constants(self, setup_inputs: SetupInputs) -> None:
         constants = get_constants()
+        self._export_file("Constants", constants, setup_inputs.out, CONSTANTS_FILE_NAME)
+
+    def _export_manifest(self, setup_inputs: Manifest) -> None:
         self._export_file(
-            "Election constants", constants, setup_inputs.out, CONSTANTS_FILE_NAME
+            "Manifest",
+            setup_inputs.manifest,
+            setup_inputs.out,
+            MANIFEST_FILE_NAME,
         )
 
     def _export_guardian_records(self, setup_inputs: SetupInputs) -> None:

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -1,6 +1,5 @@
 from os.path import join
 from electionguard.election import CiphertextElectionContext
-from electionguard.manifest import Manifest
 from electionguard.serialize import to_file
 from electionguard.constants import get_constants
 from electionguard_tools.helpers.export import (


### PR DESCRIPTION
### Issue

Fixes #634 

### Description
The guardian import was looking in a file not for all files in a folder, this fixes that.

### Testing
Run something like `poetry run eg import-ballots --manifest=../data/import/manifest.json --context=../data/import/context.json --ballots-dir=../data/import/ballots --guardian-keys=../data/import/guardian_private_data --encryption-device=../data/import/device_91755434160.json --output-record=../data/import-publish-results.zip`
