### PR TITLE
🔢 #640 Remove Sequence Order from Plaintext Ballots

### DIFF
--- a/data/election_manifest_simple.json
+++ b/data/election_manifest_simple.json
@@ -209,26 +209,26 @@
   "contests": [
     {
       "object_id": "justice-supreme-court",
-      "sequence_order": 0,
+      "sequence_order": 1,
       "ballot_selections": [
         {
           "object_id": "john-adams-selection",
-          "sequence_order": 0,
+          "sequence_order": 1,
           "candidate_id": "john-adams"
         },
         {
           "object_id": "benjamin-franklin-selection",
-          "sequence_order": 1,
+          "sequence_order": 2,
           "candidate_id": "benjamin-franklin"
         },
         {
           "object_id": "john-hancock-selection",
-          "sequence_order": 2,
+          "sequence_order": 3,
           "candidate_id": "john-hancock"
         },
         {
           "object_id": "write-in-selection",
-          "sequence_order": 3,
+          "sequence_order": 4,
           "candidate_id": "write-in"
         }
       ],
@@ -264,16 +264,16 @@
     },
     {
       "object_id": "referendum-pineapple",
-      "sequence_order": 1,
+      "sequence_order": 2,
       "ballot_selections": [
         {
           "object_id": "referendum-pineapple-affirmative-selection",
-          "sequence_order": 0,
+          "sequence_order": 1,
           "candidate_id": "referendum-pineapple-affirmative"
         },
         {
           "object_id": "referendum-pineapple-negative-selection",
-          "sequence_order": 1,
+          "sequence_order": 2,
           "candidate_id": "referendum-pineapple-negative"
         }
       ],

--- a/data/plaintext_ballots_simple.json
+++ b/data/plaintext_ballots_simple.json
@@ -5,16 +5,13 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "vote": 1,
-            "sequence_order": 1
+            "vote": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -31,16 +28,13 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -57,16 +51,13 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "benjamin-franklin-selection",
-            "sequence_order": 2,
             "vote": 1
           }
         ]
@@ -79,16 +70,13 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "john-hancock-selection",
-            "sequence_order": 2,
             "vote": 1
           }
         ]
@@ -101,27 +89,22 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "john-hancock-selection",
-            "sequence_order": 2,
             "vote": 1
           }
         ]
       },
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 2,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
-            "sequence_order": 1,
             "vote": 1
           }
         ]
@@ -134,16 +117,13 @@
     "contests": [
       {
         "object_id": "justice-supreme-court",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "john-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "write-in-selection",
-            "sequence_order": 2,
             "vote": 1,
             "extended_data": {
               "value": "Susan B. Anthony",
@@ -154,11 +134,9 @@
       },
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 2,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-negative-selection",
-            "sequence_order": 1,
             "vote": 1
           }
         ]

--- a/data/plaintext_two_ballots_minimal.json
+++ b/data/plaintext_two_ballots_minimal.json
@@ -5,11 +5,9 @@
     "contests": [
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
-            "sequence_order": 0,
             "vote": 1
           }
         ]
@@ -22,11 +20,9 @@
     "contests": [
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-negative-selection",
-            "sequence_order": 1,
             "vote": 1
           }
         ]

--- a/data/plaintext_two_ballots_small.json
+++ b/data/plaintext_two_ballots_small.json
@@ -5,38 +5,31 @@
     "contests": [
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
-            "sequence_order": 0,
             "vote": 1
           }
         ]
       },
       {
         "object_id": "congressional-race-01",
-        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "john-hancock-selection",
-            "sequence_order": 0,
             "vote": 1
           }
         ]
       },
       {
         "object_id": "ozark-school-board-race",
-        "sequence_order": 2,
         "ballot_selections": [
           {
             "object_id": "samuel-adams-selection",
-            "sequence_order": 1,
             "vote": 1
           },
           {
             "object_id": "thomas-jefferson-selection",
-            "sequence_order": 2,
             "vote": 1
           }
         ]
@@ -49,22 +42,18 @@
     "contests": [
       {
         "object_id": "referendum-pineapple",
-        "sequence_order": 1,
         "ballot_selections": [
           {
             "object_id": "referendum-pineapple-affirmative-selection",
-            "sequence_order": 0,
             "vote": 1
           }
         ]
       },
       {
         "object_id": "congressional-race-01",
-        "sequence_order": 0,
         "ballot_selections": [
           {
             "object_id": "benjamin-franklin-selection",
-            "sequence_order": 1,
             "vote": 1
           }
         ]

--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -287,7 +287,7 @@ def make_ciphertext_ballot_selection(
 
 
 @dataclass(unsafe_hash=True)
-class PlaintextBallotContest(OrderedObjectBase):
+class PlaintextBallotContest(ElectionObjectBase):
     """
     A PlaintextBallotContest represents the selections made by a voter for a specific ContestDescription
 

--- a/src/electionguard/ballot.py
+++ b/src/electionguard/ballot.py
@@ -48,7 +48,7 @@ from .utils import (
 
 
 @dataclass(unsafe_hash=True)
-class PlaintextBallotSelection(OrderedObjectBase):
+class PlaintextBallotSelection(ElectionObjectBase):
     """
     A BallotSelection represents an individual selection on a ballot.
 

--- a/src/electionguard/ballot_compact.py
+++ b/src/electionguard/ballot_compact.py
@@ -168,11 +168,7 @@ def _get_plaintext_contests(
             )
             index += 1
 
-        contests.append(
-            PlaintextBallotContest(
-                manifest_contest.object_id, manifest_contest.sequence_order, selections
-            )
-        )
+        contests.append(PlaintextBallotContest(manifest_contest.object_id, selections))
     return contests
 
 

--- a/src/electionguard/ballot_compact.py
+++ b/src/electionguard/ballot_compact.py
@@ -160,7 +160,6 @@ def _get_plaintext_contests(
             selections.append(
                 PlaintextBallotSelection(
                     selection.object_id,
-                    selection.sequence_order,
                     YES_VOTE if compact_ballot.selections[index] else NO_VOTE,
                     not contest_in_style,
                     compact_ballot.write_ins.get(index),

--- a/src/electionguard/decrypt_with_secrets.py
+++ b/src/electionguard/decrypt_with_secrets.py
@@ -166,9 +166,7 @@ def decrypt_contest_with_secret(
             )
             return None
 
-    return PlaintextBallotContest(
-        contest.object_id, contest.sequence_order, plaintext_selections
-    )
+    return PlaintextBallotContest(contest.object_id, plaintext_selections)
 
 
 def decrypt_contest_with_nonce(
@@ -239,9 +237,7 @@ def decrypt_contest_with_nonce(
             )
             return None
 
-    return PlaintextBallotContest(
-        contest.object_id, contest.sequence_order, plaintext_selections
-    )
+    return PlaintextBallotContest(contest.object_id, plaintext_selections)
 
 
 def decrypt_ballot_with_secret(

--- a/src/electionguard/decrypt_with_secrets.py
+++ b/src/electionguard/decrypt_with_secrets.py
@@ -54,7 +54,6 @@ def decrypt_selection_with_secret(
 
     return PlaintextBallotSelection(
         selection.object_id,
-        selection.sequence_order,
         plaintext_vote,
         selection.is_placeholder_selection,
     )
@@ -110,7 +109,6 @@ def decrypt_selection_with_nonce(
 
     return PlaintextBallotSelection(
         selection.object_id,
-        selection.sequence_order,
         plaintext_vote,
         selection.is_placeholder_selection,
     )

--- a/src/electionguard/encrypt.py
+++ b/src/electionguard/encrypt.py
@@ -156,7 +156,6 @@ def selection_from(
 
     return PlaintextBallotSelection(
         description.object_id,
-        description.sequence_order,
         1 if is_affirmative else 0,
         is_placeholder,
     )
@@ -232,7 +231,7 @@ def encrypt_selection(
     # Create the return object
     encrypted_selection = make_ciphertext_ballot_selection(
         selection.object_id,
-        selection.sequence_order,
+        selection_description.sequence_order,
         selection_description_hash,
         get_optional(elgamal_encryption),
         elgamal_public_key,

--- a/src/electionguard/encrypt.py
+++ b/src/electionguard/encrypt.py
@@ -176,9 +176,7 @@ def contest_from(description: ContestDescription) -> PlaintextBallotContest:
     for selection_description in description.ballot_selections:
         selections.append(selection_from(selection_description))
 
-    return PlaintextBallotContest(
-        description.object_id, description.sequence_order, selections
-    )
+    return PlaintextBallotContest(description.object_id, selections)
 
 
 def encrypt_selection(
@@ -403,7 +401,7 @@ def encrypt_contest(
     # Create the return object
     encrypted_contest = make_ciphertext_ballot_contest(
         contest.object_id,
-        contest.sequence_order,
+        contest_description.sequence_order,
         contest_description_hash,
         encrypted_selections,
         elgamal_public_key,

--- a/src/electionguard_tools/factories/ballot_factory.py
+++ b/src/electionguard_tools/factories/ballot_factory.py
@@ -84,9 +84,7 @@ class BallotFactory:
             elif bool(random.randint(0, 1)) == 1:
                 selections.append(selection_from(selection_description))
 
-        return PlaintextBallotContest(
-            description.object_id, selections
-        )
+        return PlaintextBallotContest(description.object_id, selections)
 
     def get_fake_ballot(
         self,

--- a/src/electionguard_tools/factories/ballot_factory.py
+++ b/src/electionguard_tools/factories/ballot_factory.py
@@ -85,7 +85,7 @@ class BallotFactory:
                 selections.append(selection_from(selection_description))
 
         return PlaintextBallotContest(
-            description.object_id, description.sequence_order, selections
+            description.object_id, selections
         )
 
     def get_fake_ballot(

--- a/src/electionguard_tools/strategies/election.py
+++ b/src/electionguard_tools/strategies/election.py
@@ -632,9 +632,7 @@ def plaintext_voted_ballot(draw: _DrawType, internal_manifest: InternalManifest)
         ]
 
         voted_contests.append(
-            PlaintextBallotContest(
-                contest.object_id, voted_selections
-            )
+            PlaintextBallotContest(contest.object_id, voted_selections)
         )
 
     return PlaintextBallot(str(draw(uuids())), ballot_style.object_id, voted_contests)

--- a/src/electionguard_tools/strategies/election.py
+++ b/src/electionguard_tools/strategies/election.py
@@ -633,7 +633,7 @@ def plaintext_voted_ballot(draw: _DrawType, internal_manifest: InternalManifest)
 
         voted_contests.append(
             PlaintextBallotContest(
-                contest.object_id, contest.sequence_order, voted_selections
+                contest.object_id, voted_selections
             )
         )
 


### PR DESCRIPTION
### Issue

Fixes #640 

### Description
`sequence_order` currently exists on contests and ballot_selections in plaintext ballots. This PR removes it from the input and instead derives the information from the manifest.

### Testing
Running the end-to-end integration test will sufficiently test this since sequence order is removed from `plaintext_ballots_simple.json`.