### PR TITLE
🗳. Remove placeholders from decrypted ballots and tallies

### DIFF
--- a/src/electionguard/decryption_mediator.py
+++ b/src/electionguard/decryption_mediator.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional
 
-from electionguard.group import ElementModQ
 
 from .ballot import SubmittedBallot
 from .decryption import (
@@ -11,9 +10,11 @@ from .decryption import (
 from .decryption_share import DecryptionShare, CompensatedDecryptionShare
 from .decrypt_with_shares import decrypt_ballot, decrypt_tally
 from .election import CiphertextElectionContext
+from .group import ElementModQ
 from .key_ceremony import ElectionPublicKey
 from .key_ceremony_mediator import GuardianPair
 from .logs import log_info, log_warning
+from .manifest import Manifest
 from .tally import (
     CiphertextTally,
     PlaintextTally,
@@ -255,7 +256,7 @@ class DecryptionMediator:
             self._ballot_shares[ballot_id] = ballot_shares
 
     def get_plaintext_tally(
-        self, ciphertext_tally: CiphertextTally
+        self, ciphertext_tally: CiphertextTally, manifest: Manifest
     ) -> Optional[PlaintextTally]:
         """
         Get the plaintext tally for the election by composing each Guardian's
@@ -273,10 +274,11 @@ class DecryptionMediator:
             ciphertext_tally,
             self._tally_shares,
             self._context.crypto_extended_base_hash,
+            manifest,
         )
 
     def get_plaintext_ballots(
-        self, ciphertext_ballots: List[SubmittedBallot]
+        self, ciphertext_ballots: List[SubmittedBallot], manifest: Manifest
     ) -> Optional[Dict[BallotId, PlaintextTally]]:
         """
         Get the plaintext ballots for the election by composing each Guardian's
@@ -300,6 +302,7 @@ class DecryptionMediator:
                 ciphertext_ballot,
                 ballot_shares,
                 self._context.crypto_extended_base_hash,
+                manifest,
             )
 
             if ballot:

--- a/src/electionguard_cli/cli_steps/decrypt_step.py
+++ b/src/electionguard_cli/cli_steps/decrypt_step.py
@@ -3,6 +3,7 @@ import click
 from electionguard.guardian import Guardian
 from electionguard.utils import get_optional
 from electionguard.ballot import SubmittedBallot
+from electionguard.manifest import Manifest
 from electionguard.tally import CiphertextTally
 from electionguard.decryption_mediator import DecryptionMediator
 from electionguard.election_polynomial import LagrangeCoefficientsRecord
@@ -30,6 +31,7 @@ class DecryptStep(CliStepBase):
         spoiled_ballots: List[SubmittedBallot],
         guardians: List[Guardian],
         build_election_results: BuildElectionResults,
+        manifest: Manifest,
     ) -> CliDecryptResults:
         self.print_header("Decrypting tally")
 
@@ -57,11 +59,11 @@ class DecryptStep(CliStepBase):
         lagrange_coefficients = self._get_lagrange_coefficients(decryption_mediator)
 
         plaintext_tally = get_optional(
-            decryption_mediator.get_plaintext_tally(ciphertext_tally)
+            decryption_mediator.get_plaintext_tally(ciphertext_tally, manifest)
         )
 
         plaintext_spoiled_ballots = get_optional(
-            decryption_mediator.get_plaintext_ballots(spoiled_ballots)
+            decryption_mediator.get_plaintext_ballots(spoiled_ballots, manifest)
         )
 
         return CliDecryptResults(

--- a/src/electionguard_cli/e2e/e2e_command.py
+++ b/src/electionguard_cli/e2e/e2e_command.py
@@ -101,6 +101,7 @@ def E2eCommand(
         spoiled_ballots,
         election_inputs.guardians,
         build_election_results,
+        election_inputs.manifest,
     )
 
     # print results

--- a/src/electionguard_cli/import_ballots/import_ballots_command.py
+++ b/src/electionguard_cli/import_ballots/import_ballots_command.py
@@ -83,6 +83,7 @@ def ImportBallotsCommand(
         spoiled_ballots,
         election_inputs.guardians,
         build_election_results,
+        election_inputs.manifest,
     )
 
     # print results

--- a/src/electionguard_tools/scripts/sample_generator.py
+++ b/src/electionguard_tools/scripts/sample_generator.py
@@ -149,9 +149,9 @@ class ElectionSampleDataGenerator:
                 spoiled_ciphertext_ballots.values(),
             )
 
-        plaintext_tally = mediator.get_plaintext_tally(ciphertext_tally)
+        plaintext_tally = mediator.get_plaintext_tally(ciphertext_tally, manifest)
         plaintext_spoiled_ballots = mediator.get_plaintext_ballots(
-            spoiled_ciphertext_ballots.values()
+            spoiled_ciphertext_ballots.values(), manifest
         )
 
         if plaintext_tally:

--- a/src/electionguard_tools/scripts/sample_generator.py
+++ b/src/electionguard_tools/scripts/sample_generator.py
@@ -78,18 +78,18 @@ class ElectionSampleDataGenerator:
         # Configure the election
         # TODO: pass the spec version and the manifest name in
         (
-            manifest,
+            public_data,
             private_data,
         ) = self.election_factory.get_sample_manifest_with_encryption_context(
             spec_version, sample_manifest
         )
         plaintext_ballots = (
             self.ballot_factory.generate_fake_plaintext_ballots_for_election(
-                manifest.internal_manifest, number_of_ballots
+                public_data.internal_manifest, number_of_ballots
             )
         )
         self.encrypter = EncryptionMediator(
-            manifest.internal_manifest, manifest.context, self.encryption_device
+            public_data.internal_manifest, public_data.context, self.encryption_device
         )
 
         # Encrypt some ballots
@@ -101,7 +101,7 @@ class ElectionSampleDataGenerator:
 
         ballot_store = DataStore()
         ballot_box = BallotBox(
-            manifest.internal_manifest, manifest.context, ballot_store
+            public_data.internal_manifest, public_data.context, ballot_store
         )
 
         # Randomly cast/spoil the ballots
@@ -115,11 +115,13 @@ class ElectionSampleDataGenerator:
         # Tally
         spoiled_ciphertext_ballots = get_ballots(ballot_store, BallotBoxState.SPOILED)
         ciphertext_tally = get_optional(
-            tally_ballots(ballot_store, manifest.internal_manifest, manifest.context)
+            tally_ballots(
+                ballot_store, public_data.internal_manifest, public_data.context
+            )
         )
 
         # Decrypt
-        mediator = DecryptionMediator("sample-manifest-decrypter", manifest.context)
+        mediator = DecryptionMediator("sample-manifest-decrypter", public_data.context)
         available_guardians = (
             private_data.guardians
             if use_all_guardians
@@ -136,7 +138,7 @@ class ElectionSampleDataGenerator:
                 available_guardians,
                 all_guardian_keys,
                 mediator,
-                manifest.context,
+                public_data.context,
                 ciphertext_tally,
                 spoiled_ciphertext_ballots.values(),
             )
@@ -144,27 +146,27 @@ class ElectionSampleDataGenerator:
             TallyCeremonyOrchestrator.perform_decryption_setup(
                 available_guardians,
                 mediator,
-                manifest.context,
+                public_data.context,
                 ciphertext_tally,
                 spoiled_ciphertext_ballots.values(),
             )
 
-        plaintext_tally = mediator.get_plaintext_tally(ciphertext_tally, manifest)
+        plaintext_tally = mediator.get_plaintext_tally(ciphertext_tally, public_data)
         plaintext_spoiled_ballots = mediator.get_plaintext_ballots(
-            spoiled_ciphertext_ballots.values(), manifest
+            spoiled_ciphertext_ballots.values(), public_data
         )
 
         if plaintext_tally:
             export_record(
-                manifest.manifest,
-                manifest.context,
-                manifest.constants,
+                public_data.manifest,
+                public_data.context,
+                public_data.constants,
                 [self.encryption_device],
                 submitted_ballots,
                 plaintext_spoiled_ballots.values(),
                 ciphertext_tally.publish(),
                 plaintext_tally,
-                manifest.guardians,
+                public_data.guardians,
                 LagrangeCoefficientsRecord(mediator.get_lagrange_coefficients()),
             )
 

--- a/tests/integration/test_end_to_end_election.py
+++ b/tests/integration/test_end_to_end_election.py
@@ -408,7 +408,9 @@ class TestEndToEndElection(BaseTestCase):
 
         # Get the plaintext Tally
         self.plaintext_tally = get_optional(
-            self.decryption_mediator.get_plaintext_tally(self.ciphertext_tally)
+            self.decryption_mediator.get_plaintext_tally(
+                self.ciphertext_tally, self.manifest
+            )
         )
         self._assert_message(
             DecryptionMediator.get_plaintext_tally.__qualname__,
@@ -418,7 +420,9 @@ class TestEndToEndElection(BaseTestCase):
 
         # Get the plaintext Spoiled Ballots
         self.plaintext_spoiled_ballots = get_optional(
-            self.decryption_mediator.get_plaintext_ballots(submitted_ballots_list)
+            self.decryption_mediator.get_plaintext_ballots(
+                submitted_ballots_list, self.manifest
+            )
         )
         self._assert_message(
             DecryptionMediator.get_plaintext_ballots.__qualname__,

--- a/tests/property/test_decryption_mediator.py
+++ b/tests/property/test_decryption_mediator.py
@@ -77,8 +77,8 @@ class TestDecryptionMediator(BaseTestCase):
         self.assertIsNotNone(self.joint_public_key)
 
         # Setup the election
-        manifest = election_factory.get_fake_manifest()
-        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, manifest)
+        self.manifest = election_factory.get_fake_manifest()
+        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, self.manifest)
 
         self.assertIsNone(builder.build())  # Can't build without the public key
 
@@ -217,8 +217,12 @@ class TestDecryptionMediator(BaseTestCase):
         # Can only announce once
         self.assertEqual(len(mediator.get_available_guardians()), 1)
         # Cannot get plaintext tally or spoiled ballots without a quorum
-        self.assertIsNone(mediator.get_plaintext_tally(self.ciphertext_tally))
-        self.assertIsNone(mediator.get_plaintext_ballots(self.ciphertext_ballots))
+        self.assertIsNone(
+            mediator.get_plaintext_tally(self.ciphertext_tally, self.manifest)
+        )
+        self.assertIsNone(
+            mediator.get_plaintext_ballots(self.ciphertext_ballots, self.manifest)
+        )
 
     def test_get_plaintext_with_all_guardians_present(self):
         # Arrange
@@ -238,14 +242,20 @@ class TestDecryptionMediator(BaseTestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
-        plaintext_ballots = mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        plaintext_tally = mediator.get_plaintext_tally(
+            self.ciphertext_tally, self.manifest
+        )
+        plaintext_ballots = mediator.get_plaintext_ballots(
+            self.ciphertext_ballots, self.manifest
+        )
 
         # Convert to selections to check for the same tally
         selections = _convert_to_selections(plaintext_tally)
 
         # Verify we get the same tally back if we call again
-        another_plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
+        another_plaintext_tally = mediator.get_plaintext_tally(
+            self.ciphertext_tally, self.manifest
+        )
 
         # Assert
         self.assertIsNotNone(plaintext_tally)
@@ -278,14 +288,20 @@ class TestDecryptionMediator(BaseTestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
-        plaintext_ballots = mediator.get_plaintext_ballots(self.ciphertext_ballots)
+        plaintext_tally = mediator.get_plaintext_tally(
+            self.ciphertext_tally, self.manifest
+        )
+        plaintext_ballots = mediator.get_plaintext_ballots(
+            self.ciphertext_ballots, self.manifest
+        )
 
         # Convert to selections to check for the same tally
         selections = _convert_to_selections(plaintext_tally)
 
         # Verify we get the same tally back if we call again
-        another_plaintext_tally = mediator.get_plaintext_tally(self.ciphertext_tally)
+        another_plaintext_tally = mediator.get_plaintext_tally(
+            self.ciphertext_tally, self.manifest
+        )
 
         # Assert
         self.assertIsNotNone(plaintext_tally)
@@ -309,8 +325,8 @@ class TestDecryptionMediator(BaseTestCase):
         self, values, parties: int, contests: int
     ):
         # Arrange
-        description = values.draw(election_descriptions(parties, contests))
-        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, description)
+        manifest = values.draw(election_descriptions(parties, contests))
+        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, manifest)
         internal_manifest, context = (
             builder.set_public_key(self.joint_public_key.joint_public_key)
             .set_commitment_hash(self.joint_public_key.commitment_hash)
@@ -333,7 +349,7 @@ class TestDecryptionMediator(BaseTestCase):
         )
 
         # Act
-        plaintext_tally = mediator.get_plaintext_tally(encrypted_tally)
+        plaintext_tally = mediator.get_plaintext_tally(encrypted_tally, manifest)
         selections = _convert_to_selections(plaintext_tally)
 
         # Assert

--- a/tests/property/test_verify.py
+++ b/tests/property/test_verify.py
@@ -109,7 +109,7 @@ class TestVerify(BaseTestCase):
         }
 
         plaintext_tally = decrypt_tally(
-            ciphertext_tally, shares, context.crypto_extended_base_hash
+            ciphertext_tally, shares, context.crypto_extended_base_hash, manifest
         )
 
         # Act

--- a/tests/unit/test_decrypt_with_shares.py
+++ b/tests/unit/test_decrypt_with_shares.py
@@ -63,8 +63,8 @@ class TestDecryptWithShares(BaseTestCase):
         self.joint_public_key = self.key_ceremony_mediator.publish_joint_key()
 
         # Setup the election
-        manifest = election_factory.get_fake_manifest()
-        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, manifest)
+        self.manifest = election_factory.get_fake_manifest()
+        builder = ElectionBuilder(self.NUMBER_OF_GUARDIANS, self.QUORUM, self.manifest)
         builder.set_public_key(self.joint_public_key.joint_public_key)
         builder.set_commitment_hash(self.joint_public_key.commitment_hash)
         self.internal_manifest, self.context = get_optional(builder.build())
@@ -226,6 +226,7 @@ class TestDecryptWithShares(BaseTestCase):
             encrypted_ballot,
             shares,
             self.context.crypto_extended_base_hash,
+            self.manifest,
         )
 
         # assert
@@ -291,6 +292,7 @@ class TestDecryptWithShares(BaseTestCase):
             encrypted_ballot,
             all_shares,
             self.context.crypto_extended_base_hash,
+            self.manifest,
         )
 
         # assert


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #637 

### Description
- Use the Manifest to strip out any selections and contests that are not in line with Manifest. This is now the default. 
- Update the CLI and tests in line with this
- Includes boyscout rename in Sample Generator

Before
<img width="598" alt="Screen Shot 2022-05-17 at 2 39 05 PM" src="https://user-images.githubusercontent.com/10125297/168886368-367c54b9-a5fe-4780-8667-be156d769e37.png">

After
<img width="565" alt="Screen Shot 2022-05-17 at 2 40 05 PM" src="https://user-images.githubusercontent.com/10125297/168886526-05c6971d-9363-4866-a21d-5f0ea0a8ecbf.png">

### Testing
- Existing test suite should specifically run through this. 
