### PR TITLE
🪟 #620 Fix Makefile on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 
 install-gmp-windows:
 	@echo 🏁 WINDOWS INSTALL
-	@echo 🚨 Ensure pyproject.toml has been modified to include appropriate local gmpy2 package 🚨 
+	@echo 🚨 Nothing todo here. Windows should work via poetry install, without manually installing gmpy2. 🚨 
 # install module with local gmpy2 package
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,6 @@ endif
 ifeq ($(OS), Darwin)
 	make install-gmp-mac
 endif
-ifeq ($(OS), Windows)
-	make install-gmp-windows
-endif
-ifeq ($(OS), Windows_NT)
-	make install-gmp-windows
-endif
 
 install-gmp-mac:
 	@echo 🍎 MACOS INSTALL
@@ -66,11 +60,6 @@ else ifeq ($(PKG_MGR), pacman)
 else ifeq ($(PKG_MGR), undefined)
 	@echo "We could not install GMP automatically for your Linux distribution. Please, install GMP manually."
 endif
-
-install-gmp-windows:
-	@echo 🏁 WINDOWS INSTALL
-	@echo 🚨 Nothing todo here. Windows should work via poetry install, without manually installing gmpy2. 🚨 
-# install module with local gmpy2 package
 
 lint:
 	@echo 💚 LINT

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ OS ?= $(shell python3 -c 'import platform; print(platform.system())')
 ifeq ($(OS), Linux)
 PKG_MGR ?= $(shell python3 -c 'import subprocess as sub; print(next(filter(None, (sub.getstatusoutput(f"command -v {pm}")[0] == 0 and pm for pm in ["apt-get", "pacman"])), "undefined"))')
 endif
-IS_64_BIT ?= $(shell python3 -c 'from sys import maxsize; print(maxsize > 2**32)')
 SAMPLE_BALLOT_COUNT ?= 5
 SAMPLE_BALLOT_SPOIL_RATE ?= 50
 
@@ -72,12 +71,6 @@ install-gmp-windows:
 	@echo 🏁 WINDOWS INSTALL
 	@echo 🚨 Ensure pyproject.toml has been modified to include appropriate local gmpy2 package 🚨 
 # install module with local gmpy2 package
-ifeq ($(IS_64_BIT), True)
-	@echo 64 bit system detected
-endif
-ifeq ($(IS_64_BIT), False)
-	@echo 32 bit system detected
-endif
 
 lint:
 	@echo 💚 LINT

--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@ This repository is a "reference implementation" of ElectionGuard written in Pyth
 
 ## 📁 In This Repository
 
-| File/folder                                                | Description                                   |
-| --------------------------------------------------------   | --------------------------------------------  |
-| [docs](/docs)                                              | Documentation for using the library.          |
-| [src/electionguard](/src/electionguard)                    | ElectionGuard library.                        |
-| [src/electionguard_tools](/src/electionguard_tools)        | Tools for testing and sample data.            |
-| [src/electionguard_verifier](/src/electionguard_verify)      | Verifier to validate the validity of a ballot.|
-| [stubs](/stubs)                                            | Type annotations for external libraries.      |
-| [tests](/tests)                                            | Tests to exercise this codebase.              |
-| [CONTRIBUTING.md](/CONTRIBUTING.md)                        | Guidelines for contributing.                  |
-| [README.md](/README.md)                                    | This README file.                             |
-| [LICENSE](/LICENSE)                                        | The license for ElectionGuard-Python.         |
-| [data](/data)                                              | Sample election data.                         |
-
+| File/folder                                             | Description                                    |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| [docs](/docs)                                           | Documentation for using the library.           |
+| [src/electionguard](/src/electionguard)                 | ElectionGuard library.                         |
+| [src/electionguard_tools](/src/electionguard_tools)     | Tools for testing and sample data.             |
+| [src/electionguard_verifier](/src/electionguard_verify) | Verifier to validate the validity of a ballot. |
+| [stubs](/stubs)                                         | Type annotations for external libraries.       |
+| [tests](/tests)                                         | Tests to exercise this codebase.               |
+| [CONTRIBUTING.md](/CONTRIBUTING.md)                     | Guidelines for contributing.                   |
+| [README.md](/README.md)                                 | This README file.                              |
+| [LICENSE](/LICENSE)                                     | The license for ElectionGuard-Python.          |
+| [data](/data)                                           | Sample election data.                          |
 
 ## ❓ What Is ElectionGuard?
 
@@ -38,7 +37,7 @@ ElectionGuard supports a variety of use cases. The Primary use case is to genera
 - [GNU Make](https://www.gnu.org/software/make/manual/make.html) is used to simplify the commands and GitHub Actions. This approach is recommended to simplify the command line experience. This is built in for MacOS and Linux. For Windows, setup is simpler with [Chocolatey](https://chocolatey.org/install) and installing the provided [make package](https://chocolatey.org/packages/make). The other Windows option is [manually installing make](http://gnuwin32.sourceforge.net/packages/make.htm).
 - [Gmpy2](https://gmpy2.readthedocs.io/en/latest/) is used for [Arbitrary-precision arithmetic](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic) which
   has its own [installation requirements (native C libraries)](https://gmpy2.readthedocs.io/en/latest/intro.html#installation) on Linux and MacOS. **⚠️ Note:** _This is not required for Windows since the gmpy2 precompiled libraries are provided._
-- [poetry 1.1.10](https://python-poetry.org/) is used to configure the python environment. Installation instructions can be found [here](https://python-poetry.org/docs/#installation).
+- [poetry 1.1.13](https://python-poetry.org/) is used to configure the python environment. Installation instructions can be found [here](https://python-poetry.org/docs/#installation).
 
 ## 🚀 Quick Start
 
@@ -131,9 +130,7 @@ A huge thank you to those who helped to contribute to this project so far, inclu
 [pull request workflow]: https://github.com/microsoft/electionguard-python/blob/main/.github/workflows/pull_request.yml
 [contributing]: https://github.com/microsoft/electionguard-python/blob/main/CONTRIBUTING.md
 [security]: https://github.com/microsoft/electionguard-python/blob/main/SECURITY.md
-
-[Design and Architecture]: https://github.com/microsoft/electionguard-python/blob/main/docs/Design_and_Architecture.md
-
+[design and architecture]: https://github.com/microsoft/electionguard-python/blob/main/docs/Design_and_Architecture.md
 [build and run]: https://github.com/microsoft/electionguard-python/blob/main/docs/Build_and_Run.md
 [project workflow]: https://github.com/microsoft/electionguard-python/blob/main/docs/Project_Workflow.md
 [election manifest]: https://github.com/microsoft/electionguard-python/blob/main/docs/Election_Manifest.md


### PR DESCRIPTION
### Issue

Supports #620 

### Description
Minor fix to the makefile, which didn't run on Windows.  The problem was that the `>` in the embedded python script that determines 32 or 64 bit was being stripped out along with everything after it in any given statement.  It was as if something somewhere detected a cross-site scripting attack and tried to sanitize the input, but did it poorly.  I searched for a while but couldn't find any solutions, so I just removed it, since it wasn't really doing anything anyway.

Incidentally, this PR doesn't address gmpy2, and thus supports but doesn't fix the ticket as written.

### Testing
Run something simple on Windows like `make auto-lint`.  Previously it would give an error about `/5` not being a valid argument or something.