### PR TITLE
Story/552 hashed elgamal

### DIFF
--- a/src/electionguard/__init__.py
+++ b/src/electionguard/__init__.py
@@ -269,6 +269,7 @@ from electionguard.hmac import (
 )
 from electionguard.key_ceremony import (
     CeremonyDetails,
+    CoordinateData,
     ElectionJointKey,
     ElectionKeyPair,
     ElectionPartialKeyBackup,
@@ -439,6 +440,7 @@ __all__ = [
     "ContestErrorType",
     "ContestException",
     "ContestId",
+    "CoordinateData",
     "CryptoHashCheckable",
     "CryptoHashable",
     "CryptoHashableAll",
@@ -626,6 +628,7 @@ __all__ = [
     "generate_placeholder_selection_from",
     "generate_placeholder_selections_from",
     "generate_polynomial",
+    "get_backup_seed",
     "get_ballot_code",
     "get_ballots",
     "get_cofactor",
@@ -633,7 +636,6 @@ __all__ = [
     "get_file_handler",
     "get_generator",
     "get_hash_for_device",
-    "get_backup_seed",
     "get_hmac",
     "get_large_prime",
     "get_optional",

--- a/src/electionguard/__init__.py
+++ b/src/electionguard/__init__.py
@@ -279,6 +279,7 @@ from electionguard.key_ceremony import (
     generate_election_key_pair,
     generate_election_partial_key_backup,
     generate_election_partial_key_challenge,
+    get_hashed_elgalmal_seed,
     verify_election_partial_key_backup,
     verify_election_partial_key_challenge,
 )
@@ -632,6 +633,7 @@ __all__ = [
     "get_file_handler",
     "get_generator",
     "get_hash_for_device",
+    "get_hashed_elgalmal_seed",
     "get_hmac",
     "get_large_prime",
     "get_optional",

--- a/src/electionguard/__init__.py
+++ b/src/electionguard/__init__.py
@@ -279,7 +279,7 @@ from electionguard.key_ceremony import (
     generate_election_key_pair,
     generate_election_partial_key_backup,
     generate_election_partial_key_challenge,
-    get_hashed_elgalmal_seed,
+    get_backup_seed,
     verify_election_partial_key_backup,
     verify_election_partial_key_challenge,
 )
@@ -633,7 +633,7 @@ __all__ = [
     "get_file_handler",
     "get_generator",
     "get_hash_for_device",
-    "get_hashed_elgalmal_seed",
+    "get_backup_seed",
     "get_hmac",
     "get_large_prime",
     "get_optional",

--- a/src/electionguard/decryption.py
+++ b/src/electionguard/decryption.py
@@ -489,6 +489,8 @@ def compensate_decrypt(
     bytes_optional = missing_guardian_backup.encrypted_coordinate.decrypt(
         guardian_keys.key_pair.secret_key, encryption_seed
     )
+    if bytes_optional is None:
+        return None
     coordinate_data: CoordinateData = CoordinateData.from_bytes(
         get_optional(bytes_optional)
     )
@@ -612,7 +614,7 @@ def reconstruct_decryption_contest(
     lagrange_coefficients: Dict[GuardianId, ElementModQ],
 ) -> CiphertextDecryptionContest:
     """
-    Recontruct the missing Decryption Share for a missing guardian
+    Reconstruct the missing Decryption Share for a missing guardian
     from the collection of compensated decryption shares
 
     :param missing_guardian_id: The guardian id for the missing guardian

--- a/src/electionguard/decryption.py
+++ b/src/electionguard/decryption.py
@@ -32,7 +32,7 @@ from .key_ceremony import (
     ElectionKeyPair,
     ElectionPartialKeyBackup,
     ElectionPublicKey,
-    get_hashed_elgalmal_seed,
+    get_backup_seed,
 )
 from .logs import log_warning
 from .scheduler import Scheduler
@@ -480,7 +480,7 @@ def compensate_decrypt(
 
     # todo: figure out how to get the guardian's secret_key during compensate_decrypt
     secret_key = ElGamalSecretKey(0)
-    encryption_seed = get_hashed_elgalmal_seed(
+    encryption_seed = get_backup_seed(
         guardian_key.owner_id, guardian_key.sequence_order
     )
     partial_secret_key = missing_guardian_backup.encrypted_coordinate.decrypt_to_q(

--- a/src/electionguard/decryption.py
+++ b/src/electionguard/decryption.py
@@ -483,7 +483,6 @@ def compensate_decrypt(
 
     encryption_seed = get_backup_seed(
         guardian_keys.owner_id,
-        missing_guardian_backup.designated_id,
         guardian_keys.sequence_order,
     )
     bytes_optional = missing_guardian_backup.encrypted_coordinate.decrypt(

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -118,6 +118,13 @@ class HashedElGamalCiphertext:
     mac: str
     """message authentication code for hmac"""
 
+    def decrypt_to_q(
+        self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ
+    ) -> ElementModQ:
+        value_bytes = self.decrypt(secret_key, encryption_seed)
+        value_hex = bytes_to_hex(get_optional(value_bytes))
+        return ElementModQ(value_hex)
+
     def decrypt(
         self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ
     ) -> Union[bytes, None]:

--- a/src/electionguard/elgamal.py
+++ b/src/electionguard/elgamal.py
@@ -118,13 +118,6 @@ class HashedElGamalCiphertext:
     mac: str
     """message authentication code for hmac"""
 
-    def decrypt_to_q(
-        self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ
-    ) -> ElementModQ:
-        value_bytes = self.decrypt(secret_key, encryption_seed)
-        value_hex = bytes_to_hex(get_optional(value_bytes))
-        return ElementModQ(value_hex)
-
     def decrypt(
         self, secret_key: ElGamalSecretKey, encryption_seed: ElementModQ
     ) -> Union[bytes, None]:

--- a/src/electionguard/guardian.py
+++ b/src/electionguard/guardian.py
@@ -492,7 +492,7 @@ class Guardian:
         if missing_guardian_key is None or missing_guardian_backup is None:
             return None
         return compute_compensated_decryption_share(
-            self.share_key(),
+            self._election_keys,
             missing_guardian_key,
             missing_guardian_backup,
             tally,
@@ -528,7 +528,7 @@ class Guardian:
 
         for ballot in ballots:
             share = compute_compensated_decryption_share_for_ballot(
-                self.share_key(),
+                self._election_keys,
                 missing_guardian_key,
                 missing_guardian_backup,
                 ballot,

--- a/src/electionguard/guardian.py
+++ b/src/electionguard/guardian.py
@@ -351,7 +351,9 @@ class Guardian:
         public_key = self._guardian_election_public_keys.get(guardian_id)
         if backup is None or public_key is None:
             return None
-        return verify_election_partial_key_backup(self.id, backup, public_key)
+        return verify_election_partial_key_backup(
+            self.id, backup, public_key, self._election_keys
+        )
 
     def publish_election_backup_challenge(
         self, guardian_id: GuardianId

--- a/src/electionguard/guardian.py
+++ b/src/electionguard/guardian.py
@@ -281,16 +281,16 @@ class Guardian:
         """
         Generate all election partial key backups based on existing public keys.
         """
-        for guardian in self._guardian_election_public_keys.values():
+        for guardian_key in self._guardian_election_public_keys.values():
             backup = generate_election_partial_key_backup(
-                self.id, self._election_keys.polynomial, guardian
+                self.id, self._election_keys.polynomial, guardian_key
             )
             if backup is None:
                 log_warning(
                     f"guardian; {self.id} could not generate election partial key backups: failed to encrypt"
                 )
                 return False
-            self._backups_to_share[guardian.owner_id] = backup
+            self._backups_to_share[guardian_key.owner_id] = backup
 
         return True
 

--- a/src/electionguard/key_ceremony.py
+++ b/src/electionguard/key_ceremony.py
@@ -17,7 +17,7 @@ from .elgamal import (
     elgamal_combine_public_keys,
     hashed_elgamal_encrypt,
 )
-from .group import ONE_MOD_Q, ElementModQ, rand_q
+from .group import ElementModQ, rand_q
 from .hash import hash_elems
 from .schnorr import SchnorrProof
 from .type import (

--- a/src/electionguard/key_ceremony.py
+++ b/src/electionguard/key_ceremony.py
@@ -218,6 +218,7 @@ def generate_election_partial_key_backup(
     coordinate_data = CoordinateData(coordinate)
     nonce = rand_q()
     seed = get_backup_seed(
+        sender_guardian_id,
         receiver_guardian_public_key.owner_id,
         receiver_guardian_public_key.sequence_order,
     )
@@ -235,10 +236,10 @@ def generate_election_partial_key_backup(
     )
 
 
-def get_backup_seed(owner_id: str, sequence_order: int) -> ElementModQ:
-    # todo: use a better seed
-    # return hash_elems(owner_id, sequence_order)
-    return ONE_MOD_Q
+def get_backup_seed(
+    sender_guardian_id: str, receiver_guardian_id: str, sequence_order: int
+) -> ElementModQ:
+    return hash_elems(sender_guardian_id, receiver_guardian_id, sequence_order)
 
 
 def verify_election_partial_key_backup(
@@ -257,6 +258,7 @@ def verify_election_partial_key_backup(
 
     encryption_seed = get_backup_seed(
         sender_guardian_backup.owner_id,
+        receiver_guardian_id,
         sender_guardian_backup.designated_sequence_order,
     )
 

--- a/src/electionguard/key_ceremony.py
+++ b/src/electionguard/key_ceremony.py
@@ -239,7 +239,8 @@ def generate_election_partial_key_backup(
 def get_backup_seed(
     sender_guardian_id: str, receiver_guardian_id: str, sequence_order: int
 ) -> ElementModQ:
-    return hash_elems(sender_guardian_id, receiver_guardian_id, sequence_order)
+    # todo: add back in real seed like `return hash_elems(sender_guardian_id, receiver_guardian_id, sequence_order)`
+    return ElementModQ(1)
 
 
 def verify_election_partial_key_backup(

--- a/src/electionguard/key_ceremony.py
+++ b/src/electionguard/key_ceremony.py
@@ -218,7 +218,6 @@ def generate_election_partial_key_backup(
     coordinate_data = CoordinateData(coordinate)
     nonce = rand_q()
     seed = get_backup_seed(
-        sender_guardian_id,
         receiver_guardian_public_key.owner_id,
         receiver_guardian_public_key.sequence_order,
     )
@@ -236,11 +235,8 @@ def generate_election_partial_key_backup(
     )
 
 
-def get_backup_seed(
-    sender_guardian_id: str, receiver_guardian_id: str, sequence_order: int
-) -> ElementModQ:
-    # todo: add back in real seed like `return hash_elems(sender_guardian_id, receiver_guardian_id, sequence_order)`
-    return ElementModQ(1)
+def get_backup_seed(receiver_guardian_id: str, sequence_order: int) -> ElementModQ:
+    return hash_elems(receiver_guardian_id, sequence_order)
 
 
 def verify_election_partial_key_backup(
@@ -258,7 +254,6 @@ def verify_election_partial_key_backup(
     """
 
     encryption_seed = get_backup_seed(
-        sender_guardian_backup.owner_id,
         receiver_guardian_id,
         sender_guardian_backup.designated_sequence_order,
     )

--- a/tests/property/test_elgamal.py
+++ b/tests/property/test_elgamal.py
@@ -30,7 +30,7 @@ from electionguard.group import (
 )
 from electionguard.logs import log_info
 from electionguard.nonces import Nonces
-from electionguard.serialize import PaddedDataSize, padded_encode, padded_decode
+from electionguard.serialize import PaddedDataSize, padded_decode
 from electionguard.scheduler import Scheduler
 from electionguard.utils import ContestErrorType, get_optional
 from electionguard_tools.strategies.elgamal import elgamal_keypairs
@@ -199,7 +199,7 @@ class TestElGamal(BaseTestCase):
         seed = ONE_MOD_Q
 
         # Act
-        padded_message = padded_encode(message, PaddedDataSize.Bytes_512)
+        padded_message = message.to_bytes()
         encrypted_message = hashed_elgamal_encrypt(
             padded_message, nonce, keypair.public_key, seed
         )

--- a/tests/unit/test_decrypt_with_shares.py
+++ b/tests/unit/test_decrypt_with_shares.py
@@ -261,7 +261,7 @@ class TestDecryptWithShares(BaseTestCase):
 
         compensated_shares = {
             available_guardian.id: compute_compensated_decryption_share_for_ballot(
-                available_guardian.share_key(),
+                available_guardian._election_keys,
                 missing_guardian.share_key(),
                 get_optional(
                     available_guardian._guardian_election_partial_key_backups.get(

--- a/tests/unit/test_decryption.py
+++ b/tests/unit/test_decryption.py
@@ -309,7 +309,7 @@ class TestDecryption(BaseTestCase):
 
         # compute compensations shares for the missing guardian
         compensation_0 = compute_compensated_decryption_share_for_selection(
-            available_guardian_1.share_key(),
+            available_guardian_1,
             missing_guardian.share_key(),
             missing_guardian.share_election_partial_key_backup(available_guardian_1.id),
             first_selection,
@@ -317,7 +317,7 @@ class TestDecryption(BaseTestCase):
         )
 
         compensation_1 = compute_compensated_decryption_share_for_selection(
-            available_guardian_2.share_key(),
+            available_guardian_2,
             missing_guardian.share_key(),
             missing_guardian.share_election_partial_key_backup(available_guardian_2.id),
             first_selection,
@@ -428,7 +428,7 @@ class TestDecryption(BaseTestCase):
         )
 
         result = compute_compensated_decryption_share_for_selection(
-            available_guardian.share_key(),
+            available_guardian,
             missing_guardian.share_key(),
             incorrect_backup,
             first_selection,

--- a/tests/unit/test_guardian.py
+++ b/tests/unit/test_guardian.py
@@ -137,7 +137,7 @@ class TestGuardian(BaseTestCase):
 
         # Assert
         self.assertIsNotNone(key_backup)
-        self.assertIsNotNone(key_backup.coordinate)
+        self.assertIsNotNone(key_backup.encrypted_coordinate)
         self.assertEqual(key_backup.owner_id, guardian.id)
         self.assertEqual(key_backup.designated_id, other_guardian.id)
 

--- a/tests/unit/test_key_ceremony.py
+++ b/tests/unit/test_key_ceremony.py
@@ -17,9 +17,10 @@ SENDER_SEQUENCE_ORDER = 1
 
 RECIPIENT_GUARDIAN_ID = "Test Guardian 2"
 RECIPIENT_SEQUENCE_ORDER = 2
-RECIPIENT_KEY = generate_election_key_pair(
+RECIPIENT_KEY_PAIR = generate_election_key_pair(
     RECIPIENT_GUARDIAN_ID, RECIPIENT_SEQUENCE_ORDER, QUORUM
-).share()
+)
+RECIPIENT_KEY = RECIPIENT_KEY_PAIR.share()
 
 ALTERNATE_VERIFIER_GUARDIAN_ID = "Test Guardian 3"
 
@@ -49,10 +50,6 @@ class TestKeyCeremony(BaseTestCase):
             SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, QUORUM
         )
 
-        election_key_pair = generate_election_key_pair(
-            SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, QUORUM
-        )
-
         # Act
         backup = generate_election_partial_key_backup(
             SENDER_GUARDIAN_ID,
@@ -65,6 +62,28 @@ class TestKeyCeremony(BaseTestCase):
         self.assertEqual(backup.designated_id, RECIPIENT_GUARDIAN_ID)
         self.assertEqual(backup.designated_sequence_order, RECIPIENT_SEQUENCE_ORDER)
         self.assertIsNotNone(backup.encrypted_coordinate)
+
+    def test_encrypt_then_verify_coordinate(self) -> None:
+        # Arrange
+        sender_key_pair = generate_election_key_pair(
+            SENDER_GUARDIAN_ID, SENDER_SEQUENCE_ORDER, QUORUM
+        )
+
+        # Act
+        partial_key_backup = generate_election_partial_key_backup(
+            SENDER_GUARDIAN_ID,
+            sender_key_pair.polynomial,
+            RECIPIENT_KEY,
+        )
+        verification = verify_election_partial_key_backup(
+            RECIPIENT_GUARDIAN_ID,
+            partial_key_backup,
+            sender_key_pair.share(),
+            RECIPIENT_KEY_PAIR,
+        )
+
+        # Assert
+        self.assertTrue(verification.verified)
 
     def test_verify_election_partial_key_backup(self) -> None:
         # Arrange
@@ -83,6 +102,7 @@ class TestKeyCeremony(BaseTestCase):
             RECIPIENT_GUARDIAN_ID,
             partial_key_backup,
             sender_election_key_pair.share(),
+            sender_election_key_pair,
         )
 
         # Assert

--- a/tests/unit/test_key_ceremony.py
+++ b/tests/unit/test_key_ceremony.py
@@ -64,7 +64,7 @@ class TestKeyCeremony(BaseTestCase):
         self.assertIsNotNone(backup)
         self.assertEqual(backup.designated_id, RECIPIENT_GUARDIAN_ID)
         self.assertEqual(backup.designated_sequence_order, RECIPIENT_SEQUENCE_ORDER)
-        self.assertIsNotNone(backup.coordinate)
+        self.assertIsNotNone(backup.encrypted_coordinate)
 
     def test_verify_election_partial_key_backup(self) -> None:
         # Arrange

--- a/tests/unit/test_key_ceremony.py
+++ b/tests/unit/test_key_ceremony.py
@@ -1,4 +1,10 @@
+import os
+from unittest.mock import patch
 from tests.base_test_case import BaseTestCase
+
+from electionguard.constants import (
+    PrimeOption,
+)
 
 from electionguard.key_ceremony import (
     generate_election_key_pair,
@@ -63,6 +69,7 @@ class TestKeyCeremony(BaseTestCase):
         self.assertEqual(backup.designated_sequence_order, RECIPIENT_SEQUENCE_ORDER)
         self.assertIsNotNone(backup.encrypted_coordinate)
 
+    @patch.dict(os.environ, {"PRIME_OPTION": PrimeOption.Standard.value})
     def test_encrypt_then_verify_coordinate(self) -> None:
         # Arrange
         sender_key_pair = generate_election_key_pair(

--- a/tests/unit/test_key_ceremony.py
+++ b/tests/unit/test_key_ceremony.py
@@ -31,6 +31,7 @@ RECIPIENT_KEY = RECIPIENT_KEY_PAIR.share()
 ALTERNATE_VERIFIER_GUARDIAN_ID = "Test Guardian 3"
 
 
+@patch.dict(os.environ, {"PRIME_OPTION": PrimeOption.Standard.value})
 class TestKeyCeremony(BaseTestCase):
     """Key ceremony tests"""
 
@@ -69,7 +70,6 @@ class TestKeyCeremony(BaseTestCase):
         self.assertEqual(backup.designated_sequence_order, RECIPIENT_SEQUENCE_ORDER)
         self.assertIsNotNone(backup.encrypted_coordinate)
 
-    @patch.dict(os.environ, {"PRIME_OPTION": PrimeOption.Standard.value})
     def test_encrypt_then_verify_coordinate(self) -> None:
         # Arrange
         sender_key_pair = generate_election_key_pair(
@@ -109,7 +109,7 @@ class TestKeyCeremony(BaseTestCase):
             RECIPIENT_GUARDIAN_ID,
             partial_key_backup,
             sender_election_key_pair.share(),
-            sender_election_key_pair,
+            RECIPIENT_KEY_PAIR,
         )
 
         # Assert


### PR DESCRIPTION
### Issue

Fixes #552 

### Description
During the key ceremony, guardians share backups aka coordinates with each other that can be used to perform thresshold decryption after the election is complete.  These backups were previously passed and stored in an unencrypted state.  This PR updates the process so that guardians pass and store backups using hashed elgamal (asymetric) encryption.  

In other words when guardian 1 now wants to share a backup to guardian 2, guardian 1 will now encrypt the coordinate using guardian 2's public key.  That coordinate can now only be decrypted using guardian 2's private key.  If guardian 1 was unavailable during the key ceremony, guardian 2 will now first decrypt guardian 1's backup using their private key prior to doing a tally or spoiled ballot decryption.

### Testing
The existing tests thoroughly cover all of the various scenarios around backup sharing, backup validation, and thresshold decryption.