### PR TITLE
🧑‍💻 #648 election setup package separation

### DIFF
--- a/src/electionguard_cli/__init__.py
+++ b/src/electionguard_cli/__init__.py
@@ -73,6 +73,7 @@ from electionguard_cli.import_ballots import (
     import_ballots_publish_step,
 )
 from electionguard_cli.setup_election import (
+    ENCRYPTION_PACKAGE_DIR,
     OutputSetupFilesStep,
     SetupElectionCommand,
     SetupInputRetrievalStep,
@@ -96,6 +97,7 @@ __all__ = [
     "E2eInputRetrievalStep",
     "E2eInputs",
     "E2ePublishStep",
+    "ENCRYPTION_PACKAGE_DIR",
     "ElectionBuilderStep",
     "EncryptBallotInputs",
     "EncryptBallotsCommand",

--- a/src/electionguard_cli/cli_steps/output_step_base.py
+++ b/src/electionguard_cli/cli_steps/output_step_base.py
@@ -26,7 +26,7 @@ class OutputStepBase(CliStepBase):
             to_file(private_guardian_record, file_name, file_path)
         self.print_value("Guardian private keys", output_keys)
         self.print_warning(
-            f"The files in {file_path} are secret and should be protected securely and not shared publicly."
+            f"The files in {file_path} are secret and should be protected securely and not shared."
         )
 
     @staticmethod

--- a/src/electionguard_cli/setup_election/__init__.py
+++ b/src/electionguard_cli/setup_election/__init__.py
@@ -4,6 +4,7 @@ from electionguard_cli.setup_election import setup_input_retrieval_step
 from electionguard_cli.setup_election import setup_inputs
 
 from electionguard_cli.setup_election.output_setup_files_step import (
+    ENCRYPTION_PACKAGE_DIR,
     OutputSetupFilesStep,
 )
 from electionguard_cli.setup_election.setup_election_command import (
@@ -17,6 +18,7 @@ from electionguard_cli.setup_election.setup_inputs import (
 )
 
 __all__ = [
+    "ENCRYPTION_PACKAGE_DIR",
     "OutputSetupFilesStep",
     "SetupElectionCommand",
     "SetupInputRetrievalStep",

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -1,5 +1,6 @@
 from os import path
 from os.path import join
+from shutil import make_archive
 from electionguard.election import CiphertextElectionContext
 from electionguard.serialize import to_file
 from electionguard.constants import get_constants
@@ -29,6 +30,13 @@ class OutputSetupFilesStep(OutputStepBase):
         self._export_manifest(setup_inputs)
         self._export_guardian_records(setup_inputs)
         self._export_guardian_private_keys(setup_inputs)
+        if setup_inputs.zip:
+            self._zip(setup_inputs)
+
+    def _zip(self, setup_inputs: SetupInputs) -> None:
+        dir_to_zip = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        file_name = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        make_archive(file_name, self._COMPRESSION_FORMAT, dir_to_zip)
 
     def _export_context(
         self, setup_inputs: SetupInputs, context: CiphertextElectionContext

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -1,6 +1,6 @@
 from os import path
 from os.path import join
-from shutil import make_archive
+from shutil import make_archive, rmtree
 from electionguard.election import CiphertextElectionContext
 from electionguard.serialize import to_file
 from electionguard.constants import get_constants
@@ -29,14 +29,16 @@ class OutputSetupFilesStep(OutputStepBase):
         self._export_constants(setup_inputs)
         self._export_manifest(setup_inputs)
         self._export_guardian_records(setup_inputs)
-        self._export_guardian_private_keys(setup_inputs)
         if setup_inputs.zip:
             self._zip(setup_inputs)
+        self._export_guardian_private_keys(setup_inputs)
 
     def _zip(self, setup_inputs: SetupInputs) -> None:
         dir_to_zip = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
         file_name = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
         make_archive(file_name, self._COMPRESSION_FORMAT, dir_to_zip)
+        rmtree(dir_to_zip)
+        self.print_value("Election record", f"{file_name}.{self._COMPRESSION_FORMAT}")
 
     def _export_context(
         self, setup_inputs: SetupInputs, context: CiphertextElectionContext

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -43,20 +43,20 @@ class OutputSetupFilesStep(OutputStepBase):
     def _export_context(
         self, setup_inputs: SetupInputs, context: CiphertextElectionContext
     ) -> None:
-        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
-        self._export_file("Context", context, outDir, CONTEXT_FILE_NAME)
+        out_dir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        self._export_file("Context", context, out_dir, CONTEXT_FILE_NAME)
 
     def _export_constants(self, setup_inputs: SetupInputs) -> None:
         constants = get_constants()
-        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
-        self._export_file("Constants", constants, outDir, CONSTANTS_FILE_NAME)
+        out_dir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        self._export_file("Constants", constants, out_dir, CONSTANTS_FILE_NAME)
 
     def _export_manifest(self, setup_inputs: SetupInputs) -> None:
-        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        out_dir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
         self._export_file(
             "Manifest",
             setup_inputs.manifest,
-            outDir,
+            out_dir,
             MANIFEST_FILE_NAME,
         )
 

--- a/src/electionguard_cli/setup_election/output_setup_files_step.py
+++ b/src/electionguard_cli/setup_election/output_setup_files_step.py
@@ -1,3 +1,4 @@
+from os import path
 from os.path import join
 from electionguard.election import CiphertextElectionContext
 from electionguard.serialize import to_file
@@ -12,6 +13,8 @@ from electionguard_tools.helpers.export import (
 from .setup_inputs import SetupInputs
 from ..cli_models.e2e_build_election_results import BuildElectionResults
 from ..cli_steps import OutputStepBase
+
+ENCRYPTION_PACKAGE_DIR = "public_encryption_package"
 
 
 class OutputSetupFilesStep(OutputStepBase):
@@ -30,22 +33,27 @@ class OutputSetupFilesStep(OutputStepBase):
     def _export_context(
         self, setup_inputs: SetupInputs, context: CiphertextElectionContext
     ) -> None:
-        self._export_file("Context", context, setup_inputs.out, CONTEXT_FILE_NAME)
+        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        self._export_file("Context", context, outDir, CONTEXT_FILE_NAME)
 
     def _export_constants(self, setup_inputs: SetupInputs) -> None:
         constants = get_constants()
-        self._export_file("Constants", constants, setup_inputs.out, CONSTANTS_FILE_NAME)
+        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
+        self._export_file("Constants", constants, outDir, CONSTANTS_FILE_NAME)
 
     def _export_manifest(self, setup_inputs: SetupInputs) -> None:
+        outDir = path.join(setup_inputs.out, ENCRYPTION_PACKAGE_DIR)
         self._export_file(
             "Manifest",
             setup_inputs.manifest,
-            setup_inputs.out,
+            outDir,
             MANIFEST_FILE_NAME,
         )
 
     def _export_guardian_records(self, setup_inputs: SetupInputs) -> None:
-        guardian_records_dir = join(setup_inputs.out, "guardians")
+        guardian_records_dir = join(
+            setup_inputs.out, ENCRYPTION_PACKAGE_DIR, "guardians"
+        )
         guardian_records = OutputStepBase._get_guardian_records(setup_inputs)
         for guardian_record in guardian_records:
             to_file(
@@ -56,5 +64,5 @@ class OutputSetupFilesStep(OutputStepBase):
         self.print_value("Guardian records", guardian_records_dir)
 
     def _export_guardian_private_keys(self, setup_inputs: SetupInputs) -> None:
-        guardian_keys_dir = join(setup_inputs.out, "guardian_private_data")
+        guardian_keys_dir = join(setup_inputs.out, "private_guardian_data")
         self._export_private_keys(guardian_keys_dir, setup_inputs.guardians)

--- a/src/electionguard_cli/setup_election/setup_election_command.py
+++ b/src/electionguard_cli/setup_election/setup_election_command.py
@@ -32,19 +32,20 @@ from .setup_input_retrieval_step import SetupInputRetrievalStep
     + "context, constants, and guardian keys. Existing files will be overwritten.",
     type=click.Path(exists=False, dir_okay=True, file_okay=False, resolve_path=True),
 )
+@click.option("--zip/--no-zip", default=False)
 def SetupElectionCommand(
-    guardian_count: int, quorum: int, manifest: TextIOWrapper, out: str
+    guardian_count: int, quorum: int, manifest: TextIOWrapper, out: str, zip: bool
 ) -> None:
     """
     This command runs an automated key ceremony and produces the files
     necessary to encrypt ballots, decrypt an election, and produce an election record.
     """
 
-    election_inputs = SetupInputRetrievalStep().get_inputs(
-        guardian_count, quorum, manifest, out
+    setup_inputs = SetupInputRetrievalStep().get_inputs(
+        guardian_count, quorum, manifest, out, zip
     )
-    joint_key = KeyCeremonyStep().run_key_ceremony(election_inputs.guardians)
+    joint_key = KeyCeremonyStep().run_key_ceremony(setup_inputs.guardians)
     build_election_results = ElectionBuilderStep().build_election_with_key(
-        election_inputs, joint_key
+        setup_inputs, joint_key
     )
-    OutputSetupFilesStep().output(election_inputs, build_election_results)
+    OutputSetupFilesStep().output(setup_inputs, build_election_results)

--- a/src/electionguard_cli/setup_election/setup_input_retrieval_step.py
+++ b/src/electionguard_cli/setup_election/setup_input_retrieval_step.py
@@ -13,7 +13,12 @@ class SetupInputRetrievalStep(InputRetrievalStepBase):
     """Responsible for retrieving and parsing user provided inputs for the CLI's setup election command."""
 
     def get_inputs(
-        self, guardian_count: int, quorum: int, manifest_file: TextIOWrapper, out: str
+        self,
+        guardian_count: int,
+        quorum: int,
+        manifest_file: TextIOWrapper,
+        out: str,
+        zip: bool,
     ) -> SetupInputs:
 
         self.print_header("Retrieving Inputs")
@@ -22,4 +27,4 @@ class SetupInputRetrievalStep(InputRetrievalStepBase):
         )
         manifest: Manifest = self._get_manifest(manifest_file)
 
-        return SetupInputs(guardian_count, quorum, guardians, manifest, out)
+        return SetupInputs(guardian_count, quorum, guardians, manifest, out, zip)

--- a/src/electionguard_cli/setup_election/setup_inputs.py
+++ b/src/electionguard_cli/setup_election/setup_inputs.py
@@ -16,11 +16,13 @@ class SetupInputs(CliElectionInputsBase):
         guardians: List[Guardian],
         manifest: Manifest,
         out: str,
+        zip: bool,
     ):
         self.guardian_count = guardian_count
         self.quorum = quorum
         self.guardians = guardians
         self.manifest = manifest
         self.out = out
+        self.zip = zip
 
     out: str


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #648 

### Description
The guardian private key were previously output into the same directory as the context and manifest.  In this PR all guardian private keys are put into `[out]/private_guardian_data` and everything else is output into `[out]/public_encryption_package`.  Furthermore if you specify `--zip` as a parameter to the `eg setup` command, then it will zip up everything in `[out]/public_encryption_package`, place it into `[out]\public_encryption_package.zip`, and delete the source directory.

### Testing
Run `poetry run eg setup --guardian-count=2 --quorum=2 --manifest=data/election_manifest_simple.json  --out=../data/setup-election-out --zip`

You should get back something like this:

![image](https://user-images.githubusercontent.com/1769905/171925441-13619cf4-c4c4-4a6b-a8fa-46e6bd550c52.png)
