### PR TITLE
🎯 Remove generate sample data target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all environment openssl-fix install install-gmp install-gmp-mac install-gmp-linux install-gmp-windows install-mkdocs auto-lint validate test test-example bench coverage coverage-html coverage-xml coverage-erase fetch-sample-data generate-sample-data
+.PHONY: all environment openssl-fix install install-gmp install-gmp-mac install-gmp-linux install-gmp-windows install-mkdocs auto-lint validate test test-example bench coverage coverage-html coverage-xml coverage-erase fetch-sample-data
 
 CODE_COVERAGE ?= 90
 OS ?= $(shell python3 -c 'import platform; print(platform.system())')
@@ -186,10 +186,6 @@ endif
 	unzip -o sample-data.zip
 	unzip sample-data.zip
 
-generate-sample-data:
-	@echo 🔁 GENERATE Sample Data
-	poetry run python3 src/electionguard_tools/scripts/sample_generator.py -m "hamilton-general" -n $(SAMPLE_BALLOT_COUNT) -s $(SAMPLE_BALLOT_SPOIL_RATE)
-
 # Publish
 publish:
 	poetry publish
@@ -205,12 +201,12 @@ publish-test-ci:
 	@echo 🚀 PUBLISH TEST
 	poetry publish --repository testpypi --username __token__ --password $(TEST_PYPI_TOKEN)
 
-publish-validate:	
+publish-validate:
 	@echo ✅ VALIDATE
 	python3 -m pip install --no-deps electionguard
 	python3 -c 'import electionguard'
 
-publish-validate-test:	
+publish-validate-test:
 	@echo ✅ VALIDATE
 	python3 -m pip install --index-url https://test.pypi.org/simple/ --no-deps electionguard
 	python3 -c 'import electionguard'


### PR DESCRIPTION
### Issue
Fixes #650 

### Description
Removes the deprecated `generate-sample-data` target and cleans up some extra tabs

### Testing
Simple change no testing required