### PR TITLE
🖨️ #29 print names

### DIFF
--- a/src/electionguard/manifest.py
+++ b/src/electionguard/manifest.py
@@ -807,7 +807,7 @@ class Manifest(CryptoHashable):
 
     def _get_candidate_name(self, candidate: Candidate, lang: str) -> str:
         if candidate.is_write_in:
-            return "write-in"
+            return "Write-In"
         query = (t.value for t in candidate.name.text if t.language == lang)
         name = next(query, None)
         name = candidate.object_id if name is None else name
@@ -843,6 +843,14 @@ class Manifest(CryptoHashable):
         selections = self._get_selections_with_candidate_id()
         self._replace_candidate_ids_with_names(selections, candidates)
         return selections
+
+    def get_contest_names(self) -> Dict[str, str]:
+        """
+        Retrieves a dictionary whose keys are all contest id's and whose values are
+        those contest's names
+        """
+
+        return {contest.object_id: contest.name for contest in self.contests}
 
 
 @dataclass(eq=True, unsafe_hash=True)

--- a/src/electionguard/manifest.py
+++ b/src/electionguard/manifest.py
@@ -805,6 +805,27 @@ class Manifest(CryptoHashable):
             )
         return success
 
+    def get_selection_names(self, lang: str) -> dict[str, str]:
+        """
+        Retrieves a dictionary whose keys are all selection id's and whose values are
+        those selection's candidate names in the supplied language if available
+        """
+        selections: dict[str, str] = {}
+        for contest in self.contests:
+            for selection in contest.ballot_selections:
+                selections.update({selection.object_id: selection.candidate_id})
+        candidates: dict[str, str] = {}
+        for candidate in self.candidates:
+            query = (t.value for t in candidate.name.text if t.language == lang)
+            name = next(query, None)
+            name = candidate.object_id if name is None else name
+            candidates.update({candidate.object_id: name})
+        for (selection_id, candidate_id) in selections.items():
+            candidate_name = candidates.get(candidate_id)
+            if candidate_name is not None:
+                selections.update({selection_id: candidate_name})
+        return selections
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class InternalManifest:

--- a/src/electionguard/manifest.py
+++ b/src/electionguard/manifest.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field, InitVar
 from datetime import datetime
 from enum import Enum, unique
-from typing import cast, List, Optional, Set, Any
+from typing import Dict, cast, List, Optional, Set, Any
 
 from .election_object_base import ElectionObjectBase, OrderedObjectBase, list_eq
 from .group import ElementModQ
@@ -813,28 +813,28 @@ class Manifest(CryptoHashable):
         name = candidate.object_id if name is None else name
         return name
 
-    def _get_candidate_names(self, lang: str) -> dict[str, str]:
+    def _get_candidate_names(self, lang: str) -> Dict[str, str]:
         return {
             candidate.object_id: self._get_candidate_name(candidate, lang)
             for candidate in self.candidates
         }
 
-    def _get_selections_with_candidate_id(self) -> dict[str, str]:
-        selections: dict[str, str] = {}
+    def _get_selections_with_candidate_id(self) -> Dict[str, str]:
+        selections: Dict[str, str] = {}
         for contest in self.contests:
             for selection in contest.ballot_selections:
                 selections.update({selection.object_id: selection.candidate_id})
         return selections
 
     def _replace_candidate_ids_with_names(
-        self, selections: dict[str, str], candidates: dict[str, str]
+        self, selections: Dict[str, str], candidates: Dict[str, str]
     ) -> None:
         for (selection_id, candidate_id) in selections.items():
             candidate_name = candidates.get(candidate_id)
             if candidate_name is not None:
                 selections.update({selection_id: candidate_name})
 
-    def get_selection_names(self, lang: str) -> dict[str, str]:
+    def get_selection_names(self, lang: str) -> Dict[str, str]:
         """
         Retrieves a dictionary whose keys are all selection id's and whose values are
         those selection's candidate names in the supplied language if available

--- a/src/electionguard_cli/cli_steps/print_results_step.py
+++ b/src/electionguard_cli/cli_steps/print_results_step.py
@@ -1,5 +1,7 @@
 from typing import Dict
 import click
+from electionguard import ContestData
+from electionguard.manifest import ContestDescription, Manifest
 from electionguard.type import BallotId
 from electionguard.tally import (
     PlaintextTally,
@@ -12,29 +14,36 @@ from .cli_step_base import CliStepBase
 class PrintResultsStep(CliStepBase):
     """Responsible for printing the results of an end-to-end election."""
 
-    def _print_tally(self, plaintext_tally: PlaintextTally) -> None:
+    def _print_tally(self, plaintext_tally: PlaintextTally, manifest: Manifest) -> None:
         self.print_header("Decrypted tally")
-        for contest in plaintext_tally.contests.values():
-            self.print_value("Contest", contest.object_id)
-            for selection in contest.selections.values():
+        for tally_contest in plaintext_tally.contests.values():
+            contest_name = self._get_contest_name(manifest, tally_contest.object_id)
+            self.print_value("Contest", contest_name)
+            for selection in tally_contest.selections.values():
                 self.print_value(f"  {selection.object_id}", selection.tally)
+
+    def _get_contest_name(self, manifest: Manifest, contest_id: str) -> str:
+        matching_contests = (c for c in manifest.contests if c.object_id == contest_id)
+        contest = next(matching_contests, None)
+        return contest_id if contest is None else contest.name
 
     def _print_spoiled_ballots(
         self,
         plaintext_spoiled_ballots: Dict[BallotId, PlaintextTally],
+        manifest: Manifest,
     ) -> None:
         ballot_ids = plaintext_spoiled_ballots.keys()
         for ballot_id in ballot_ids:
             self.print_header(f"Spoiled ballot '{ballot_id}'")
             spoiled_ballot = plaintext_spoiled_ballots[ballot_id]
             for contest in spoiled_ballot.contests.values():
-                click.echo(f"Contest: {contest.object_id}")
+                contest_name = self._get_contest_name(manifest, contest.object_id)
+                self.print_value("Contest", contest_name)
                 for selection in contest.selections.values():
                     self.print_value(f"  {selection.object_id}", selection.tally)
 
     def print_election_results(
-        self,
-        decrypt_results: CliDecryptResults,
+        self, decrypt_results: CliDecryptResults, manifest: Manifest
     ) -> None:
-        self._print_tally(decrypt_results.plaintext_tally)
-        self._print_spoiled_ballots(decrypt_results.plaintext_spoiled_ballots)
+        self._print_tally(decrypt_results.plaintext_tally, manifest)
+        self._print_spoiled_ballots(decrypt_results.plaintext_spoiled_ballots, manifest)

--- a/src/electionguard_cli/cli_steps/print_results_step.py
+++ b/src/electionguard_cli/cli_steps/print_results_step.py
@@ -1,7 +1,5 @@
 from typing import Dict
-import click
-from electionguard import ContestData
-from electionguard.manifest import ContestDescription, Manifest
+from electionguard.manifest import Manifest
 from electionguard.type import BallotId
 from electionguard.tally import (
     PlaintextTally,
@@ -18,17 +16,20 @@ class PrintResultsStep(CliStepBase):
         self,
         plaintext_tally: PlaintextTally,
         manifest: Manifest,
-        selection_names: dict[str:str],
+        selection_names: Dict[str, str],
     ) -> None:
         self.print_header("Decrypted tally")
         for tally_contest in plaintext_tally.contests.values():
-            contest_name = self._get_contest_name(manifest, tally_contest.object_id)
+            contest_name = PrintResultsStep._get_contest_name(
+                manifest, tally_contest.object_id
+            )
             self.print_value("Contest", contest_name)
             for selection in tally_contest.selections.values():
                 name = selection_names[selection.object_id]
                 self.print_value(f"  {name}", selection.tally)
 
-    def _get_contest_name(self, manifest: Manifest, contest_id: str) -> str:
+    @staticmethod
+    def _get_contest_name(manifest: Manifest, contest_id: str) -> str:
         matching_contests = (c for c in manifest.contests if c.object_id == contest_id)
         contest = next(matching_contests, None)
         return contest_id if contest is None else contest.name
@@ -37,7 +38,7 @@ class PrintResultsStep(CliStepBase):
         self,
         plaintext_spoiled_ballots: Dict[BallotId, PlaintextTally],
         manifest: Manifest,
-        selection_names: dict[str:str],
+        selection_names: Dict[str, str],
     ) -> None:
         ballot_ids = plaintext_spoiled_ballots.keys()
         for ballot_id in ballot_ids:

--- a/src/electionguard_cli/e2e/e2e_command.py
+++ b/src/electionguard_cli/e2e/e2e_command.py
@@ -105,7 +105,7 @@ def E2eCommand(
     )
 
     # print results
-    PrintResultsStep().print_election_results(decrypt_results)
+    PrintResultsStep().print_election_results(decrypt_results, election_inputs.manifest)
 
     # publish election record
     E2ePublishStep().export(

--- a/src/electionguard_cli/import_ballots/import_ballots_command.py
+++ b/src/electionguard_cli/import_ballots/import_ballots_command.py
@@ -87,7 +87,7 @@ def ImportBallotsCommand(
     )
 
     # print results
-    PrintResultsStep().print_election_results(decrypt_results)
+    PrintResultsStep().print_election_results(decrypt_results, election_inputs.manifest)
 
     # publish election record
     ImportBallotsPublishStep().publish(

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -26,8 +26,9 @@ ballot_factory = BallotFactory.BallotFactory()
 class TestManifest(BaseTestCase):
     """Manifest tests"""
 
+    @staticmethod
     def _set_selection(
-        self, manifest: Manifest, selection_id: str, candidate_id: str
+        manifest: Manifest, selection_id: str, candidate_id: str
     ) -> None:
         selection = SelectionDescription(selection_id, 1, candidate_id)
         contest = ContestDescription(
@@ -42,8 +43,8 @@ class TestManifest(BaseTestCase):
         )
         manifest.contests = [contest]
 
+    @staticmethod
     def _set_candidate(
-        self,
         manifest: Manifest,
         candidate_id: str,
         name: str,
@@ -57,8 +58,8 @@ class TestManifest(BaseTestCase):
     def test_get_selection_names_with_valid_selection(self) -> None:
         # arrange
         manifest = election_factory.get_simple_manifest_from_file()
-        self._set_selection(manifest, "selection1", "candidate1")
-        self._set_candidate(manifest, "candidate1", "My Candidate", "en")
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
         # act
         selection_names = manifest.get_selection_names("en")
@@ -70,8 +71,8 @@ class TestManifest(BaseTestCase):
     def test_get_selection_names_with_missing_language(self) -> None:
         # arrange
         manifest = election_factory.get_simple_manifest_from_file()
-        self._set_selection(manifest, "selection1", "candidate1")
-        self._set_candidate(manifest, "candidate1", "My Candidate", "en")
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
         # act
         selection_names = manifest.get_selection_names("es")
@@ -83,7 +84,7 @@ class TestManifest(BaseTestCase):
     def test_get_selection_names_with_missing_candidate(self) -> None:
         # arrange
         manifest = election_factory.get_simple_manifest_from_file()
-        self._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
         manifest.candidates = []
 
         # act
@@ -96,8 +97,8 @@ class TestManifest(BaseTestCase):
     def test_get_selection_names_with_write_in(self) -> None:
         # arrange
         manifest = election_factory.get_simple_manifest_from_file()
-        self._set_selection(manifest, "selection1", "candidate1")
-        self._set_candidate(manifest, "candidate1", "", "en", write_in=True)
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "", "en", write_in=True)
 
         # act
         selection_names = manifest.get_selection_names("es")

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -105,7 +105,7 @@ class TestManifest(BaseTestCase):
 
         # assert
         self.assertEqual(1, len(selection_names.keys()))
-        self.assertEqual("write-in", selection_names["selection1"])
+        self.assertEqual("Write-In", selection_names["selection1"])
 
     def test_simple_manifest_is_valid(self) -> None:
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -4,7 +4,11 @@ from datetime import datetime
 from tests.base_test_case import BaseTestCase
 
 from electionguard.manifest import (
+    Candidate,
+    ContestDescription,
     ContestDescriptionWithPlaceholders,
+    InternationalizedText,
+    Language,
     Manifest,
     InternalManifest,
     SelectionDescription,
@@ -22,86 +26,86 @@ ballot_factory = BallotFactory.BallotFactory()
 class TestManifest(BaseTestCase):
     """Manifest tests"""
 
-    # @staticmethod
-    # def _set_selection(
-    #     manifest: Manifest, selection_id: str, candidate_id: str
-    # ) -> None:
-    #     selection = SelectionDescription(selection_id, 1, candidate_id)
-    #     contest = ContestDescription(
-    #         "contest1",
-    #         1,
-    #         "e1",
-    #         VoteVariationType.approval,
-    #         1,
-    #         1,
-    #         "contest",
-    #         [selection],
-    #     )
-    #     manifest.contests = [contest]
+    @staticmethod
+    def _set_selection(
+        manifest: Manifest, selection_id: str, candidate_id: str
+    ) -> None:
+        selection = SelectionDescription(selection_id, 1, candidate_id)
+        contest = ContestDescription(
+            "contest1",
+            1,
+            "e1",
+            VoteVariationType.approval,
+            1,
+            1,
+            "contest",
+            [selection],
+        )
+        manifest.contests = [contest]
 
-    # @staticmethod
-    # def _set_candidate(
-    #     manifest: Manifest,
-    #     candidate_id: str,
-    #     name: str,
-    #     lang: str,
-    #     write_in: bool = False,
-    # ) -> None:
-    #     text_name = InternationalizedText([Language(name, lang)])
-    #     candidate = Candidate(candidate_id, text_name, is_write_in=write_in)
-    #     manifest.candidates = [candidate]
+    @staticmethod
+    def _set_candidate(
+        manifest: Manifest,
+        candidate_id: str,
+        name: str,
+        lang: str,
+        write_in: bool = False,
+    ) -> None:
+        text_name = InternationalizedText([Language(name, lang)])
+        candidate = Candidate(candidate_id, text_name, is_write_in=write_in)
+        manifest.candidates = [candidate]
 
-    # def test_get_selection_names_with_valid_selection(self) -> None:
-    #     # arrange
-    #     manifest = election_factory.get_simple_manifest_from_file()
-    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
-    #     TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
+    def test_get_selection_names_with_valid_selection(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
-    #     # act
-    #     selection_names = manifest.get_selection_names("en")
+        # act
+        selection_names = manifest.get_selection_names("en")
 
-    #     # assert
-    #     self.assertEqual(1, len(selection_names.keys()))
-    #     self.assertEqual("My Candidate", selection_names["selection1"])
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("My Candidate", selection_names["selection1"])
 
-    # def test_get_selection_names_with_missing_language(self) -> None:
-    #     # arrange
-    #     manifest = election_factory.get_simple_manifest_from_file()
-    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
-    #     TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
+    def test_get_selection_names_with_missing_language(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
-    #     # act
-    #     selection_names = manifest.get_selection_names("es")
+        # act
+        selection_names = manifest.get_selection_names("es")
 
-    #     # assert
-    #     self.assertEqual(1, len(selection_names.keys()))
-    #     self.assertEqual("candidate1", selection_names["selection1"])
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("candidate1", selection_names["selection1"])
 
-    # def test_get_selection_names_with_missing_candidate(self) -> None:
-    #     # arrange
-    #     manifest = election_factory.get_simple_manifest_from_file()
-    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
-    #     manifest.candidates = []
+    def test_get_selection_names_with_missing_candidate(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        manifest.candidates = []
 
-    #     # act
-    #     selection_names = manifest.get_selection_names("es")
+        # act
+        selection_names = manifest.get_selection_names("es")
 
-    #     # assert
-    #     self.assertEqual(1, len(selection_names.keys()))
-    #     self.assertEqual("candidate1", selection_names["selection1"])
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("candidate1", selection_names["selection1"])
 
-    # def test_get_selection_names_with_write_in(self) -> None:
-    #     # arrange
-    #     manifest = election_factory.get_simple_manifest_from_file()
-    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
-    #     TestManifest._set_candidate(manifest, "candidate1", "", "en", write_in=True)
+    def test_get_selection_names_with_write_in(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        TestManifest._set_selection(manifest, "selection1", "candidate1")
+        TestManifest._set_candidate(manifest, "candidate1", "", "en", write_in=True)
 
-    #     # act
-    #     selection_names = manifest.get_selection_names("es")
+        # act
+        selection_names = manifest.get_selection_names("es")
 
-    #     # assert
-    #     self.assertEqual(1, len(selection_names.keys()))
-    #     self.assertEqual("Write-In", selection_names["selection1"])
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("Write-In", selection_names["selection1"])
 
     def test_simple_manifest_is_valid(self) -> None:
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -4,11 +4,7 @@ from datetime import datetime
 from tests.base_test_case import BaseTestCase
 
 from electionguard.manifest import (
-    Candidate,
-    ContestDescription,
     ContestDescriptionWithPlaceholders,
-    InternationalizedText,
-    Language,
     Manifest,
     InternalManifest,
     SelectionDescription,
@@ -26,86 +22,86 @@ ballot_factory = BallotFactory.BallotFactory()
 class TestManifest(BaseTestCase):
     """Manifest tests"""
 
-    @staticmethod
-    def _set_selection(
-        manifest: Manifest, selection_id: str, candidate_id: str
-    ) -> None:
-        selection = SelectionDescription(selection_id, 1, candidate_id)
-        contest = ContestDescription(
-            "contest1",
-            1,
-            "e1",
-            VoteVariationType.approval,
-            1,
-            1,
-            "contest",
-            [selection],
-        )
-        manifest.contests = [contest]
+    # @staticmethod
+    # def _set_selection(
+    #     manifest: Manifest, selection_id: str, candidate_id: str
+    # ) -> None:
+    #     selection = SelectionDescription(selection_id, 1, candidate_id)
+    #     contest = ContestDescription(
+    #         "contest1",
+    #         1,
+    #         "e1",
+    #         VoteVariationType.approval,
+    #         1,
+    #         1,
+    #         "contest",
+    #         [selection],
+    #     )
+    #     manifest.contests = [contest]
 
-    @staticmethod
-    def _set_candidate(
-        manifest: Manifest,
-        candidate_id: str,
-        name: str,
-        lang: str,
-        write_in: bool = False,
-    ) -> None:
-        text_name = InternationalizedText([Language(name, lang)])
-        candidate = Candidate(candidate_id, text_name, is_write_in=write_in)
-        manifest.candidates = [candidate]
+    # @staticmethod
+    # def _set_candidate(
+    #     manifest: Manifest,
+    #     candidate_id: str,
+    #     name: str,
+    #     lang: str,
+    #     write_in: bool = False,
+    # ) -> None:
+    #     text_name = InternationalizedText([Language(name, lang)])
+    #     candidate = Candidate(candidate_id, text_name, is_write_in=write_in)
+    #     manifest.candidates = [candidate]
 
-    def test_get_selection_names_with_valid_selection(self) -> None:
-        # arrange
-        manifest = election_factory.get_simple_manifest_from_file()
-        TestManifest._set_selection(manifest, "selection1", "candidate1")
-        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
+    # def test_get_selection_names_with_valid_selection(self) -> None:
+    #     # arrange
+    #     manifest = election_factory.get_simple_manifest_from_file()
+    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
+    #     TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
-        # act
-        selection_names = manifest.get_selection_names("en")
+    #     # act
+    #     selection_names = manifest.get_selection_names("en")
 
-        # assert
-        self.assertEqual(1, len(selection_names.keys()))
-        self.assertEqual("My Candidate", selection_names["selection1"])
+    #     # assert
+    #     self.assertEqual(1, len(selection_names.keys()))
+    #     self.assertEqual("My Candidate", selection_names["selection1"])
 
-    def test_get_selection_names_with_missing_language(self) -> None:
-        # arrange
-        manifest = election_factory.get_simple_manifest_from_file()
-        TestManifest._set_selection(manifest, "selection1", "candidate1")
-        TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
+    # def test_get_selection_names_with_missing_language(self) -> None:
+    #     # arrange
+    #     manifest = election_factory.get_simple_manifest_from_file()
+    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
+    #     TestManifest._set_candidate(manifest, "candidate1", "My Candidate", "en")
 
-        # act
-        selection_names = manifest.get_selection_names("es")
+    #     # act
+    #     selection_names = manifest.get_selection_names("es")
 
-        # assert
-        self.assertEqual(1, len(selection_names.keys()))
-        self.assertEqual("candidate1", selection_names["selection1"])
+    #     # assert
+    #     self.assertEqual(1, len(selection_names.keys()))
+    #     self.assertEqual("candidate1", selection_names["selection1"])
 
-    def test_get_selection_names_with_missing_candidate(self) -> None:
-        # arrange
-        manifest = election_factory.get_simple_manifest_from_file()
-        TestManifest._set_selection(manifest, "selection1", "candidate1")
-        manifest.candidates = []
+    # def test_get_selection_names_with_missing_candidate(self) -> None:
+    #     # arrange
+    #     manifest = election_factory.get_simple_manifest_from_file()
+    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
+    #     manifest.candidates = []
 
-        # act
-        selection_names = manifest.get_selection_names("es")
+    #     # act
+    #     selection_names = manifest.get_selection_names("es")
 
-        # assert
-        self.assertEqual(1, len(selection_names.keys()))
-        self.assertEqual("candidate1", selection_names["selection1"])
+    #     # assert
+    #     self.assertEqual(1, len(selection_names.keys()))
+    #     self.assertEqual("candidate1", selection_names["selection1"])
 
-    def test_get_selection_names_with_write_in(self) -> None:
-        # arrange
-        manifest = election_factory.get_simple_manifest_from_file()
-        TestManifest._set_selection(manifest, "selection1", "candidate1")
-        TestManifest._set_candidate(manifest, "candidate1", "", "en", write_in=True)
+    # def test_get_selection_names_with_write_in(self) -> None:
+    #     # arrange
+    #     manifest = election_factory.get_simple_manifest_from_file()
+    #     TestManifest._set_selection(manifest, "selection1", "candidate1")
+    #     TestManifest._set_candidate(manifest, "candidate1", "", "en", write_in=True)
 
-        # act
-        selection_names = manifest.get_selection_names("es")
+    #     # act
+    #     selection_names = manifest.get_selection_names("es")
 
-        # assert
-        self.assertEqual(1, len(selection_names.keys()))
-        self.assertEqual("Write-In", selection_names["selection1"])
+    #     # assert
+    #     self.assertEqual(1, len(selection_names.keys()))
+    #     self.assertEqual("Write-In", selection_names["selection1"])
 
     def test_simple_manifest_is_valid(self) -> None:
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -4,7 +4,11 @@ from datetime import datetime
 from tests.base_test_case import BaseTestCase
 
 from electionguard.manifest import (
+    Candidate,
+    ContestDescription,
     ContestDescriptionWithPlaceholders,
+    InternationalizedText,
+    Language,
     Manifest,
     InternalManifest,
     SelectionDescription,
@@ -21,6 +25,68 @@ ballot_factory = BallotFactory.BallotFactory()
 
 class TestManifest(BaseTestCase):
     """Manifest tests"""
+
+    def _set_selection(
+        self, manifest: Manifest, selection_id: str, candidate_id: str
+    ) -> None:
+        selection = SelectionDescription(selection_id, 1, candidate_id)
+        contest = ContestDescription(
+            "contest1",
+            1,
+            "e1",
+            VoteVariationType.approval,
+            1,
+            1,
+            "contest",
+            [selection],
+        )
+        manifest.contests = [contest]
+
+    def _set_candidate(
+        self, manifest: Manifest, candidate_id: str, name: str, lang: str
+    ) -> None:
+        text_name = InternationalizedText([Language(name, lang)])
+        candidate = Candidate(candidate_id, text_name)
+        manifest.candidates = [candidate]
+
+    def test_get_selection_names_with_valid_selection(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        self._set_selection(manifest, "selection1", "candidate1")
+        self._set_candidate(manifest, "candidate1", "My Candidate", "en")
+
+        # act
+        selection_names = manifest.get_selection_names("en")
+
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("My Candidate", selection_names["selection1"])
+
+    def test_get_selection_names_with_missing_language(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        self._set_selection(manifest, "selection1", "candidate1")
+        self._set_candidate(manifest, "candidate1", "My Candidate", "en")
+
+        # act
+        selection_names = manifest.get_selection_names("es")
+
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("candidate1", selection_names["selection1"])
+
+    def test_get_selection_names_with_missing_candidate(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        self._set_selection(manifest, "selection1", "candidate1")
+        manifest.candidates = []
+
+        # act
+        selection_names = manifest.get_selection_names("es")
+
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("candidate1", selection_names["selection1"])
 
     def test_simple_manifest_is_valid(self) -> None:
 

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -43,10 +43,15 @@ class TestManifest(BaseTestCase):
         manifest.contests = [contest]
 
     def _set_candidate(
-        self, manifest: Manifest, candidate_id: str, name: str, lang: str
+        self,
+        manifest: Manifest,
+        candidate_id: str,
+        name: str,
+        lang: str,
+        write_in: bool = False,
     ) -> None:
         text_name = InternationalizedText([Language(name, lang)])
-        candidate = Candidate(candidate_id, text_name)
+        candidate = Candidate(candidate_id, text_name, is_write_in=write_in)
         manifest.candidates = [candidate]
 
     def test_get_selection_names_with_valid_selection(self) -> None:
@@ -87,6 +92,19 @@ class TestManifest(BaseTestCase):
         # assert
         self.assertEqual(1, len(selection_names.keys()))
         self.assertEqual("candidate1", selection_names["selection1"])
+
+    def test_get_selection_names_with_write_in(self) -> None:
+        # arrange
+        manifest = election_factory.get_simple_manifest_from_file()
+        self._set_selection(manifest, "selection1", "candidate1")
+        self._set_candidate(manifest, "candidate1", "", "en", write_in=True)
+
+        # act
+        selection_names = manifest.get_selection_names("es")
+
+        # assert
+        self.assertEqual(1, len(selection_names.keys()))
+        self.assertEqual("write-in", selection_names["selection1"])
 
     def test_simple_manifest_is_valid(self) -> None:
 


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Addresses #659

### Description
Now when you import ballots and do a tally the CLI will display contest names and candidate names rather than the id's.

### Testing
New tests cover most of the core functionality, however run an import to be sure.
