### PR TITLE
💻 #667 Separate the output dir params of election setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,4 +235,4 @@ eg-e2e-simple-election:
 	poetry run eg e2e --guardian-count=2 --quorum=2 --manifest=data/election_manifest_simple.json --ballots=data/plaintext_ballots_simple.json --spoil-id=25a7111b-4334-425a-87c1-f7a49f42b3a2 --output-record="./election_record.zip"
 
 eg-setup-simple-election:
-	poetry run eg setup --guardian-count=2 --quorum=2 --manifest=data/election_manifest_simple.json  --out=../data/out
+	poetry run eg setup --guardian-count=2 --quorum=2 --manifest=data/election_manifest_simple.json  --package-dir=../data/out/public_encryption_package --keys-dir=../data/out/test_data_private_guardian_data

--- a/src/electionguard_cli/__init__.py
+++ b/src/electionguard_cli/__init__.py
@@ -73,7 +73,6 @@ from electionguard_cli.import_ballots import (
     import_ballots_publish_step,
 )
 from electionguard_cli.setup_election import (
-    ENCRYPTION_PACKAGE_DIR,
     OutputSetupFilesStep,
     SetupElectionCommand,
     SetupInputRetrievalStep,
@@ -97,7 +96,6 @@ __all__ = [
     "E2eInputRetrievalStep",
     "E2eInputs",
     "E2ePublishStep",
-    "ENCRYPTION_PACKAGE_DIR",
     "ElectionBuilderStep",
     "EncryptBallotInputs",
     "EncryptBallotsCommand",

--- a/src/electionguard_cli/setup_election/__init__.py
+++ b/src/electionguard_cli/setup_election/__init__.py
@@ -4,7 +4,6 @@ from electionguard_cli.setup_election import setup_input_retrieval_step
 from electionguard_cli.setup_election import setup_inputs
 
 from electionguard_cli.setup_election.output_setup_files_step import (
-    ENCRYPTION_PACKAGE_DIR,
     OutputSetupFilesStep,
 )
 from electionguard_cli.setup_election.setup_election_command import (
@@ -18,7 +17,6 @@ from electionguard_cli.setup_election.setup_inputs import (
 )
 
 __all__ = [
-    "ENCRYPTION_PACKAGE_DIR",
     "OutputSetupFilesStep",
     "SetupElectionCommand",
     "SetupInputRetrievalStep",

--- a/src/electionguard_cli/setup_election/setup_election_command.py
+++ b/src/electionguard_cli/setup_election/setup_election_command.py
@@ -26,15 +26,25 @@ from .setup_input_retrieval_step import SetupInputRetrievalStep
     type=click.File(),
 )
 @click.option(
-    "--out",
-    prompt="Output directory",
+    "--package-dir",
+    prompt="Election Package Output Directory",
     help="The location of a directory into which will be placed the output files such as "
     + "context, constants, and guardian keys. Existing files will be overwritten.",
     type=click.Path(exists=False, dir_okay=True, file_okay=False, resolve_path=True),
 )
-@click.option("--zip/--no-zip", default=False)
+@click.option(
+    "--keys-dir",
+    prompt="Private guardian keys directory",
+    help="The location of a directory into which will be placed the guardian's private keys "
+    + "This folder should be protected. Existing files will be overwritten.",
+    type=click.Path(exists=False, dir_okay=True, file_okay=False, resolve_path=True),
+)
 def SetupElectionCommand(
-    guardian_count: int, quorum: int, manifest: TextIOWrapper, out: str, zip: bool
+    guardian_count: int,
+    quorum: int,
+    manifest: TextIOWrapper,
+    package_dir: str,
+    keys_dir: str,
 ) -> None:
     """
     This command runs an automated key ceremony and produces the files
@@ -42,10 +52,14 @@ def SetupElectionCommand(
     """
 
     setup_inputs = SetupInputRetrievalStep().get_inputs(
-        guardian_count, quorum, manifest, out, zip
+        guardian_count,
+        quorum,
+        manifest,
     )
     joint_key = KeyCeremonyStep().run_key_ceremony(setup_inputs.guardians)
     build_election_results = ElectionBuilderStep().build_election_with_key(
         setup_inputs, joint_key
     )
-    OutputSetupFilesStep().output(setup_inputs, build_election_results)
+    OutputSetupFilesStep().output(
+        setup_inputs, build_election_results, package_dir, keys_dir
+    )

--- a/src/electionguard_cli/setup_election/setup_input_retrieval_step.py
+++ b/src/electionguard_cli/setup_election/setup_input_retrieval_step.py
@@ -17,8 +17,6 @@ class SetupInputRetrievalStep(InputRetrievalStepBase):
         guardian_count: int,
         quorum: int,
         manifest_file: TextIOWrapper,
-        out: str,
-        zip: bool,
     ) -> SetupInputs:
 
         self.print_header("Retrieving Inputs")
@@ -27,4 +25,4 @@ class SetupInputRetrievalStep(InputRetrievalStepBase):
         )
         manifest: Manifest = self._get_manifest(manifest_file)
 
-        return SetupInputs(guardian_count, quorum, guardians, manifest, out, zip)
+        return SetupInputs(guardian_count, quorum, guardians, manifest)

--- a/src/electionguard_cli/setup_election/setup_inputs.py
+++ b/src/electionguard_cli/setup_election/setup_inputs.py
@@ -15,14 +15,8 @@ class SetupInputs(CliElectionInputsBase):
         quorum: int,
         guardians: List[Guardian],
         manifest: Manifest,
-        out: str,
-        zip: bool,
     ):
         self.guardian_count = guardian_count
         self.quorum = quorum
         self.guardians = guardians
         self.manifest = manifest
-        self.out = out
-        self.zip = zip
-
-    out: str


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #667 

### Description
In the election setup CLI command this replaces the `--out` parameter with a `--package-dir` param and a `--keys-dir` param.  Also, it now prompts prior to overwriting existing guardian private keys.

### Testing
Run `make eg-setup-simple-election`, it should pass
