### PR TITLE
#702 Make `mark-ballots` selections match `number_elected`

### DIFF
--- a/src/electionguard_cli/cli_steps/mark_ballots_step.py
+++ b/src/electionguard_cli/cli_steps/mark_ballots_step.py
@@ -18,6 +18,10 @@ class MarkBallotsStep(CliStepBase):
         internal_manifest = build_election_results.internal_manifest
         ballot_factory = BallotFactory()
         plaintext_ballots = ballot_factory.generate_fake_plaintext_ballots_for_election(
-            internal_manifest, num_ballots, ballot_style_id
+            internal_manifest,
+            num_ballots,
+            ballot_style_id,
+            allow_null_votes=False,
+            allow_under_votes=False,
         )
         return MarkResults(plaintext_ballots)


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue

Fixes #702

### Description
`eg mark-ballots` doesn't undervote or null vote anymore.

### Testing
Besides verifying that this fixes #702, double-check that this doesn't accidentally reduce the set of ballots we test against.