### PR TITLE
Fix sample data CI failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,6 @@ ifeq ($(OS), Windows)
 endif
 	wget https://github.com/microsoft/electionguard/releases/download/v0.95.0/sample-data.zip
 	unzip -o sample-data.zip
-	unzip sample-data.zip
 
 # Publish
 publish:


### PR DESCRIPTION
### Issue

na

### Description
Sample data was previously being double-zipped and then in this repo double unzipped.  That was fixed recently and that caused CI to fail.  This fixes it by removing the double-unzipping.

### Testing
CI should pass.