### PR TITLE
#687 Announce Guardians (#6a)

### DIFF
--- a/src/electionguard/key_ceremony_mediator.py
+++ b/src/electionguard/key_ceremony_mediator.py
@@ -92,7 +92,7 @@ class KeyCeremonyMediator:
 
         guardian_keys: List[ElectionPublicKey] = []
         for guardian_id in self._get_announced_guardians():
-            if guardian_id is not requesting_guardian_id:
+            if guardian_id != requesting_guardian_id:
                 guardian_keys.append(self._election_public_keys[guardian_id])
         return guardian_keys
 

--- a/src/electionguard_gui/components/create_key_ceremony_component.py
+++ b/src/electionguard_gui/components/create_key_ceremony_component.py
@@ -52,6 +52,7 @@ class CreateKeyCeremonyComponent(ComponentBase):
             "quorum": quorum,
             "guardians_joined": [],
             "guardians_keys": [],
+            "other_keys": [],
             "created_by": self._auth_service.get_user_id(),
             "created_at": datetime.utcnow(),
         }

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -74,8 +74,18 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             #       produce an unnecessary UI refresh for the admin
             self._key_ceremony_service.notify_changed(db, key_ceremony_id)
             # todo #689 wait until all guardians have backups
+        key_ceremony["status"] = self.get_status(key_ceremony)
         # pylint: disable=no-member
         eel.refresh_key_ceremony(key_ceremony)
+
+    def get_status(self, key_ceremony: Any) -> str:
+        guardians_joined_count = len(key_ceremony["guardians_joined"])
+        guardian_count = key_ceremony["guardian_count"]
+        if guardians_joined_count < guardian_count:
+            return "waiting for guardians"
+        if len(key_ceremony["other_keys"]) == 0:
+            return "waiting for admin to announce guardians"
+        return "waiting for guardians to create backups"
 
     def announce(self, key_ceremony: Any) -> dict[str, Any]:
         other_keys = []

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -4,7 +4,12 @@ import eel
 from pymongo.database import Database
 
 from electionguard import to_file
+from electionguard.election_polynomial import PublicCommitment
 from electionguard.guardian import Guardian
+from electionguard.key_ceremony import CeremonyDetails, ElectionPublicKey
+from electionguard.key_ceremony_mediator import KeyCeremonyMediator
+from electionguard.schnorr import SchnorrProof
+from electionguard.utils import get_optional
 from electionguard_tools.helpers.export import GUARDIAN_PREFIX
 
 from electionguard_gui.services.authorization_service import AuthoriationService
@@ -29,15 +34,9 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         self.auth_service = auth_service
 
     def expose(self) -> None:
-        eel.expose(self.get_key_ceremony)
         eel.expose(self.join_key_ceremony)
         eel.expose(self.watch_key_ceremony)
         eel.expose(self.stop_watching_key_ceremony)
-
-    def get_key_ceremony(self, id: str) -> dict[str, Any]:
-        db = self.db_service.get_db()
-        key_ceremony = self.get_ceremony(db, id)
-        return eel_success(key_ceremony)
 
     def can_join_key_ceremony(self, key_ceremony) -> bool:
         user_id = self.auth_service.get_user_id()
@@ -47,7 +46,10 @@ class KeyCeremonyDetailsComponent(ComponentBase):
 
     def watch_key_ceremony(self, key_ceremony_id: str) -> None:
         db = self.db_service.get_db()
+        # retrieve and send the key ceremony to the client
+        self.on_key_ceremony_changed(key_ceremony_id)
         self.log.debug(f"watching key ceremony '{key_ceremony_id}'")
+        # start watching for key ceremony changes from guardians
         self._key_ceremony_service.watch_key_ceremonies(
             db, key_ceremony_id, self.on_key_ceremony_changed
         )
@@ -61,10 +63,70 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         self.log.info(
             f"{guardians_joined_count}/{guardian_count} guardians joined {key_ceremony_id}"
         )
-        if is_admin and guardians_joined_count >= guardian_count:
+        all_guardians_joined = guardians_joined_count >= guardian_count
+        other_keys_exist = len(key_ceremony["other_keys"]) > 0
+        if is_admin and all_guardians_joined and not other_keys_exist:
             self.log.info("all guardians have joined, announcing guardians")
+            other_keys = self.announce(key_ceremony)
+            self.log.debug(f"saving other_keys")
+            self._key_ceremony_service.save_other_keys(db, key_ceremony_id, other_keys)
+            # this notify_changed occurs inside watch_key_ceremonies and thus may
+            #       produce an unnecessary UI refresh for the admin
+            self._key_ceremony_service.notify_changed(db, key_ceremony_id)
+            # todo #689 wait until all guardians have backups
         # pylint: disable=no-member
         eel.refresh_key_ceremony(key_ceremony)
+
+    def announce(self, key_ceremony: Any) -> dict[str, Any]:
+        other_keys = []
+        quorum = key_ceremony["quorum"]
+        guardian_count = key_ceremony["guardian_count"]
+        ceremony_details = CeremonyDetails(guardian_count, quorum)
+        mediator: KeyCeremonyMediator = KeyCeremonyMediator(
+            "mediator_1", ceremony_details
+        )
+        guardians = key_ceremony["guardians_joined"]
+        for guardian_id in guardians:
+            key = self.find_key(key_ceremony, guardian_id)
+            coefficient_commitments = [
+                PublicCommitment(x) for x in key["coefficient_commitments"]
+            ]
+            coefficient_proofs = [
+                SchnorrProof(
+                    cp["public_key"],
+                    cp["commitment"],
+                    cp["challenge"],
+                    cp["response"],
+                    cp["usage"],
+                )
+                for cp in key["coefficient_proofs"]
+            ]
+            guardian_public_key = ElectionPublicKey(
+                key["owner_id"],
+                key["sequence_order"],
+                key["key"],
+                coefficient_commitments,
+                coefficient_proofs,
+            )
+            mediator.announce(guardian_public_key)
+        for guardian_id in guardians:
+            other_guardian_keys = get_optional(
+                mediator.share_announced(str(guardian_id))
+            )
+            other_keys.append(
+                {
+                    "owner_id": guardian_id,
+                    "other_keys": [
+                        self._key_ceremony_service.public_key_to_dict(key)
+                        for key in other_guardian_keys
+                    ],
+                }
+            )
+        return other_keys
+
+    def find_key(self, key_ceremony: Any, guardian_id: str) -> Any:
+        keys = key_ceremony["keys"]
+        return next(key for key in keys if key["owner_id"] == guardian_id)
 
     def stop_watching_key_ceremony(self) -> None:
         self._key_ceremony_service.stop_watching()

--- a/src/electionguard_gui/components/key_ceremony_list_component.py
+++ b/src/electionguard_gui/components/key_ceremony_list_component.py
@@ -5,7 +5,7 @@ from electionguard_gui.components.component_base import ComponentBase
 from electionguard_gui.services.key_ceremony_service import KeyCeremonyService
 
 
-class GuardianHomeComponent(ComponentBase):
+class KeyCeremonyListComponent(ComponentBase):
     """Responsible for functionality related to the guardian home page"""
 
     _key_ceremony_service: KeyCeremonyService

--- a/src/electionguard_gui/components/key_ceremony_list_component.py
+++ b/src/electionguard_gui/components/key_ceremony_list_component.py
@@ -23,7 +23,7 @@ class KeyCeremonyListComponent(ComponentBase):
         db = self.db_service.get_db()
         send_key_ceremonies_to_ui(db)
         self._key_ceremony_service.watch_key_ceremonies(
-            db, None, lambda: send_key_ceremonies_to_ui(db)
+            db, None, lambda _: send_key_ceremonies_to_ui(db)
         )
         self.log.debug("exited watching key_ceremonies")
 

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -2,7 +2,9 @@ from dependency_injector import containers, providers
 from electionguard_gui.components.create_key_ceremony_component import (
     CreateKeyCeremonyComponent,
 )
-from electionguard_gui.components.guardian_home_component import GuardianHomeComponent
+from electionguard_gui.components.key_ceremony_list_component import (
+    KeyCeremonyListComponent,
+)
 from electionguard_gui.components.key_ceremony_details_component import (
     KeyCeremonyDetailsComponent,
 )
@@ -25,7 +27,7 @@ class Container(containers.DeclarativeContainer):
 
     # components
     guardian_home_component = providers.Factory(
-        GuardianHomeComponent, key_ceremony_service=key_ceremony_service
+        KeyCeremonyListComponent, key_ceremony_service=key_ceremony_service
     )
     create_key_ceremony_component = providers.Factory(
         CreateKeyCeremonyComponent,

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -5,7 +5,9 @@ from electionguard_gui.components.component_base import ComponentBase
 from electionguard_gui.components.create_key_ceremony_component import (
     CreateKeyCeremonyComponent,
 )
-from electionguard_gui.components.guardian_home_component import GuardianHomeComponent
+from electionguard_gui.components.key_ceremony_list_component import (
+    KeyCeremonyListComponent,
+)
 from electionguard_gui.components.key_ceremony_details_component import (
     KeyCeremonyDetailsComponent,
 )
@@ -29,7 +31,7 @@ class MainApp:
         self,
         log_service: EelLogService,
         db_service: DbService,
-        guardian_home_component: GuardianHomeComponent,
+        guardian_home_component: KeyCeremonyListComponent,
         create_key_ceremony_component: CreateKeyCeremonyComponent,
         key_ceremony_details_component: KeyCeremonyDetailsComponent,
         setup_election_component: SetupElectionComponent,
@@ -61,6 +63,7 @@ class MainApp:
 
             self.db_service.verify_db_connection()
             eel.init("src/electionguard_gui/web")
+            self.log_service.debug("Starting eel")
             eel.start("main.html", size=(1024, 768), port=0)
         except Exception as e:
             self.log_service.error(e)

--- a/src/electionguard_gui/services/key_ceremony_service.py
+++ b/src/electionguard_gui/services/key_ceremony_service.py
@@ -30,7 +30,7 @@ class KeyCeremonyService(ServiceBase):
         self,
         db: Database,
         key_ceremony_id: Optional[str],
-        on_found: Callable,
+        on_found: Callable[[str], None],
     ) -> None:
         # retrieve a tailable cursor of the deltas in key ceremony to avoid polling
         cursor = db.key_ceremony_deltas.find(
@@ -52,7 +52,7 @@ class KeyCeremonyService(ServiceBase):
                 changed_id = delta["key_ceremony_id"]
                 if key_ceremony_id is None or key_ceremony_id == changed_id:
                     print("new key ceremony delta found")
-                    on_found()
+                    on_found(changed_id)
 
             except StopIteration:
                 # the tailable cursor times out after a few seconds and fires a StopIteration exception,

--- a/src/electionguard_gui/services/key_ceremony_service.py
+++ b/src/electionguard_gui/services/key_ceremony_service.py
@@ -122,3 +122,13 @@ class KeyCeremonyService(ServiceBase):
             {"_id": ObjectId(key_ceremony_id)},
             {"$push": {"other_keys": {"$each": keys}}},
         )
+
+
+def get_key_ceremony_status(key_ceremony: Any) -> str:
+    guardians_joined_count = len(key_ceremony["guardians_joined"])
+    guardian_count = key_ceremony["guardian_count"]
+    if guardians_joined_count < guardian_count:
+        return "waiting for guardians"
+    if len(key_ceremony["other_keys"]) == 0:
+        return "waiting for admin to announce guardians"
+    return "waiting for guardians to create backups"

--- a/src/electionguard_gui/web/components/admin/admin-home-component.js
+++ b/src/electionguard_gui/web/components/admin/admin-home-component.js
@@ -1,4 +1,9 @@
+import KeyCeremonyList from "../shared/key-ceremony-list-component.js";
+
 export default {
+  components: {
+    KeyCeremonyList,
+  },
   template: /*html*/ `
   <div class="container col-6">
     <div class="text-center mb-4">
@@ -12,5 +17,11 @@ export default {
         <a href="#/admin/setup-election" class="btn btn-primary">Setup Election</a>
       </div>
     </div>
-  </div>`,
+  </div>
+  <div class="text-center mt-4">
+    <h2>Key Ceremonies</h2>
+    <key-ceremony-list :is-admin="true"></key-ceremony-list>
+  </div>
+
+  `,
 };

--- a/src/electionguard_gui/web/components/admin/admin-home-component.js
+++ b/src/electionguard_gui/web/components/admin/admin-home-component.js
@@ -19,7 +19,7 @@ export default {
     </div>
   </div>
   <div class="text-center mt-4">
-    <h2>Key Ceremonies</h2>
+    <h2>Active Key Ceremonies</h2>
     <key-ceremony-list :is-admin="true"></key-ceremony-list>
   </div>
 

--- a/src/electionguard_gui/web/components/guardian/guardian-home-component.js
+++ b/src/electionguard_gui/web/components/guardian/guardian-home-component.js
@@ -6,7 +6,7 @@ export default {
   },
   template: /*html*/ `
   <h1>Guardian Home</h1>
-  <h2>Key Ceremonies</h2>
+  <h2>Active Key Ceremonies</h2>
   <key-ceremony-list :is-admin="false"></key-ceremony-list>
   `,
 };

--- a/src/electionguard_gui/web/components/guardian/guardian-home-component.js
+++ b/src/electionguard_gui/web/components/guardian/guardian-home-component.js
@@ -1,40 +1,12 @@
-import RouterService from "/services/router-service.js";
+import KeyCeremonyList from "../shared/key-ceremony-list-component.js";
 
 export default {
-  data() {
-    return {
-      keyCeremonies: [],
-    };
-  },
-  methods: {
-    key_ceremonies_found: function (key_ceremonies) {
-      this.keyCeremonies = key_ceremonies;
-    },
-    getKeyCeremonyUrl: function (keyCeremony) {
-      return RouterService.getUrl(
-        RouterService.routes.viewKeyCeremonyGuardianPage,
-        {
-          keyCeremonyId: keyCeremony.id,
-        }
-      );
-    },
-  },
-  async mounted() {
-    console.log("begin watching for key ceremonies");
-    eel.expose(this.key_ceremonies_found, "key_ceremonies_found");
-    eel.watch_key_ceremonies();
-  },
-  unmounted() {
-    console.log("stop watching key ceremonies");
-    eel.stop_watching_key_ceremonies();
+  components: {
+    KeyCeremonyList,
   },
   template: /*html*/ `
   <h1>Guardian Home</h1>
   <h2>Key Ceremonies</h2>
-  <p v-if="!keyCeremonies">No key ceremonies found...</p>
-
-  <div v-if="keyCeremonies" class="d-grid gap-2 d-md-block">
-    <a :href="getKeyCeremonyUrl(keyCeremony)" v-for="keyCeremony in keyCeremonies" class="btn btn-primary me-2 mt-2">{{ keyCeremony.key_ceremony_name }}</a>
-  </div>
+  <key-ceremony-list :is-admin="false"></key-ceremony-list>
   `,
 };

--- a/src/electionguard_gui/web/components/shared/key-ceremony-details-component.js
+++ b/src/electionguard_gui/web/components/shared/key-ceremony-details-component.js
@@ -20,9 +20,6 @@ export default {
     },
   },
   async mounted() {
-    const keyCeremony = await eel.get_key_ceremony(this.keyCeremonyId)();
-    console.log("found a key ceremony", keyCeremony.result);
-    this.keyCeremony = keyCeremony.result;
     eel.expose(this.refresh_key_ceremony, "refresh_key_ceremony");
     eel.watch_key_ceremony(this.keyCeremonyId);
   },

--- a/src/electionguard_gui/web/components/shared/key-ceremony-details-component.js
+++ b/src/electionguard_gui/web/components/shared/key-ceremony-details-component.js
@@ -30,8 +30,9 @@ export default {
   template: /*html*/ `
     <div v-if="keyCeremony">
       <h1>{{keyCeremony.key_ceremony_name}}</h1>
-      <p>Quorum: {{keyCeremony.quorum}}</p>
+      <p>Status: {{keyCeremony.status}}</p>
       <p>Guardians: {{keyCeremony.guardian_count}}</p>
+      <p>Quorum: {{keyCeremony.quorum}}</p>
       <p>Created by: {{keyCeremony.created_by}}, {{keyCeremony.created_at_str}}</p>
       <h2>Joined Guardians</h2>
       <ul v-if="keyCeremony.guardians_joined.length">

--- a/src/electionguard_gui/web/components/shared/key-ceremony-list-component.js
+++ b/src/electionguard_gui/web/components/shared/key-ceremony-list-component.js
@@ -1,0 +1,41 @@
+import RouterService from "/services/router-service.js";
+
+export default {
+  props: {
+    isAdmin: Boolean,
+  },
+  data() {
+    return {
+      keyCeremonies: [],
+    };
+  },
+  methods: {
+    key_ceremonies_found: function (key_ceremonies) {
+      this.keyCeremonies = key_ceremonies;
+    },
+    getKeyCeremonyUrl: function (keyCeremony) {
+      const page = this.isAdmin
+        ? RouterService.routes.viewKeyCeremonyAdminPage
+        : RouterService.routes.viewKeyCeremonyGuardianPage;
+      return RouterService.getUrl(page, {
+        keyCeremonyId: keyCeremony.id,
+      });
+    },
+  },
+  async mounted() {
+    console.log("begin watching for key ceremonies");
+    eel.expose(this.key_ceremonies_found, "key_ceremonies_found");
+    eel.watch_key_ceremonies();
+  },
+  unmounted() {
+    console.log("stop watching key ceremonies");
+    eel.stop_watching_key_ceremonies();
+  },
+  template: /*html*/ `
+  <p v-if="!keyCeremonies">No key ceremonies found...</p>
+
+  <div v-if="keyCeremonies" class="d-grid gap-2 d-md-block">
+    <a :href="getKeyCeremonyUrl(keyCeremony)" v-for="keyCeremony in keyCeremonies" class="btn btn-primary me-2 mt-2">{{ keyCeremony.key_ceremony_name }}</a>
+  </div>
+  `,
+};

--- a/src/electionguard_gui/web/components/shared/key-ceremony-list-component.js
+++ b/src/electionguard_gui/web/components/shared/key-ceremony-list-component.js
@@ -1,4 +1,5 @@
 import RouterService from "/services/router-service.js";
+import Spinner from "./spinner-component.js";
 
 export default {
   props: {
@@ -6,12 +7,17 @@ export default {
   },
   data() {
     return {
+      loading: true,
       keyCeremonies: [],
     };
+  },
+  components: {
+    Spinner,
   },
   methods: {
     key_ceremonies_found: function (key_ceremonies) {
       this.keyCeremonies = key_ceremonies;
+      this.loading = false;
     },
     getKeyCeremonyUrl: function (keyCeremony) {
       const page = this.isAdmin
@@ -32,8 +38,8 @@ export default {
     eel.stop_watching_key_ceremonies();
   },
   template: /*html*/ `
+  <spinner :visible="loading"></spinner>
   <p v-if="!keyCeremonies">No key ceremonies found...</p>
-
   <div v-if="keyCeremonies" class="d-grid gap-2 d-md-block">
     <a :href="getKeyCeremonyUrl(keyCeremony)" v-for="keyCeremony in keyCeremonies" class="btn btn-primary me-2 mt-2">{{ keyCeremony.key_ceremony_name }}</a>
   </div>


### PR DESCRIPTION
### Issue

Fixes #687 

### Description
Once all guardians have joined a key ceremony the admin will now announce them and generate "other_keys" which in the next step (6b, #688) the guardians will use to create backups.  This PR also adds a "status" field so a user can track the back-and-forth communication between guardians and admins.

### Testing
1. Create a key ceremony with 2 guardians
2. Start egui for 2 guardians
3. Have each guardian join the key ceremony

Expected #1: all UI's should now show a status field "waiting for guardians to create backups" like this:

![image](https://user-images.githubusercontent.com/1769905/179081268-edbc3291-761d-4d35-8fe9-c41713c62c80.png)

Expected #2: The database should now have a field for `other_keys` like this:

![image](https://user-images.githubusercontent.com/1769905/179081700-350bdda5-d8b1-44e7-a886-570c1407c27e.png)
