### PR TITLE
#688 6b Guardian Generate Backups

### DIFF
--- a/src/electionguard_gui/components/create_key_ceremony_component.py
+++ b/src/electionguard_gui/components/create_key_ceremony_component.py
@@ -4,7 +4,7 @@ import eel
 from electionguard_gui.components.component_base import ComponentBase
 
 from electionguard_gui.eel_utils import eel_fail, eel_success
-from electionguard_gui.services.authorization_service import AuthoriationService
+from electionguard_gui.services.authorization_service import AuthorizationService
 from electionguard_gui.services.key_ceremony_service import KeyCeremonyService
 
 
@@ -12,12 +12,12 @@ class CreateKeyCeremonyComponent(ComponentBase):
     """Responsible for functionality related to creating key ceremonies"""
 
     _key_ceremony_service: KeyCeremonyService
-    _auth_service: AuthoriationService
+    _auth_service: AuthorizationService
 
     def __init__(
         self,
         key_ceremony_service: KeyCeremonyService,
-        auth_service: AuthoriationService,
+        auth_service: AuthorizationService,
     ) -> None:
         super().__init__()
         self._key_ceremony_service = key_ceremony_service

--- a/src/electionguard_gui/components/create_key_ceremony_component.py
+++ b/src/electionguard_gui/components/create_key_ceremony_component.py
@@ -51,6 +51,7 @@ class CreateKeyCeremonyComponent(ComponentBase):
             "guardian_count": guardian_count,
             "quorum": quorum,
             "guardians_joined": [],
+            "keys": [],
             "guardians_keys": [],
             "other_keys": [],
             "backups": [],

--- a/src/electionguard_gui/components/create_key_ceremony_component.py
+++ b/src/electionguard_gui/components/create_key_ceremony_component.py
@@ -53,6 +53,7 @@ class CreateKeyCeremonyComponent(ComponentBase):
             "guardians_joined": [],
             "guardians_keys": [],
             "other_keys": [],
+            "backups": [],
             "created_by": self._auth_service.get_user_id(),
             "created_at": datetime.utcnow(),
         }

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -85,8 +85,10 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             self._key_ceremony_service.notify_changed(db, key_ceremony_id)
             # todo #689 wait until all guardians have backups
 
-        # todo: search backups to determine if current user has created backup
-        current_user_backup_exists = False
+        current_user_backups = len(
+            self.get_backups_for_user(key_ceremony, current_user_id)
+        )
+        current_user_backup_exists = current_user_backups > 0
         if is_guardian and other_keys_exist and not current_user_backup_exists:
             self.log.debug("other keys found, creating backup")
             guardian = self.load_guardian(current_user_id, key_ceremony)
@@ -109,6 +111,13 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         key_ceremony["status"] = get_key_ceremony_status(key_ceremony)
         # pylint: disable=no-member
         eel.refresh_key_ceremony(key_ceremony)
+
+    def get_backups_for_user(self, key_ceremony: Any, user_id: str) -> List[Any]:
+        return [
+            backup
+            for backup in key_ceremony["backups"]
+            if backup["owner_id"] == user_id
+        ]
 
     def find_other_keys_for_user(self, key_ceremony: Any, user_id: str) -> Any:
         return next(

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -90,9 +90,10 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         )
         current_user_backup_exists = current_user_backups > 0
         if is_guardian and other_keys_exist and not current_user_backup_exists:
-            self.log.debug("other keys found, creating backup")
+            self.log.debug(
+                f"other keys found without backup for {current_user_id}, creating backup"
+            )
             guardian = self.load_guardian(current_user_id, key_ceremony)
-            self.log.debug("guardian loaded")
 
             current_user_other_keys = self.find_other_keys_for_user(
                 key_ceremony, current_user_id
@@ -107,6 +108,8 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             guardian.generate_election_partial_key_backups()
             backups = guardian.share_election_partial_key_backups()
             self._key_ceremony_service.append_backups(db, key_ceremony_id, backups)
+            # notify the admin that a new guardian has backups
+            self._key_ceremony_service.notify_changed(db, key_ceremony_id)
 
         key_ceremony["status"] = get_key_ceremony_status(key_ceremony)
         # pylint: disable=no-member

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -118,6 +118,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             # notify the admin that a new guardian has backups
             self._key_ceremony_service.notify_changed(db, key_ceremony_id)
 
+        key_ceremony = self.get_ceremony(db, key_ceremony_id)
         new_state = self._ceremony_state_service.get_key_ceremony_state(key_ceremony)
         if state != new_state:
             self.log.debug(f"state changed from {state} to {new_state}")

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -9,12 +9,12 @@ from electionguard.key_ceremony import CeremonyDetails
 from electionguard.key_ceremony_mediator import KeyCeremonyMediator
 from electionguard.serialize import from_file
 from electionguard.utils import get_optional
+from electionguard_tools.helpers.export import GUARDIAN_PREFIX
+
 from electionguard_gui.services.db_serialization_service import (
     dict_to_election_public_key,
 )
-from electionguard_tools.helpers.export import GUARDIAN_PREFIX
-
-from electionguard_gui.services.authorization_service import AuthoriationService
+from electionguard_gui.services.authorization_service import AuthorizationService
 from electionguard_gui.services.guardian_service import make_guardian
 from electionguard_gui.components.component_base import ComponentBase
 from electionguard_gui.eel_utils import utc_to_str
@@ -27,12 +27,12 @@ from electionguard_gui.services.key_ceremony_service import (
 class KeyCeremonyDetailsComponent(ComponentBase):
     """Responsible for retrieving key ceremony details"""
 
-    auth_service: AuthoriationService
+    auth_service: AuthorizationService
 
     def __init__(
         self,
         key_ceremony_service: KeyCeremonyService,
-        auth_service: AuthoriationService,
+        auth_service: AuthorizationService,
     ) -> None:
         super().__init__()
         self._key_ceremony_service = key_ceremony_service
@@ -110,7 +110,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         # pylint: disable=no-member
         eel.refresh_key_ceremony(key_ceremony)
 
-    def find_other_keys_for_user(self, key_ceremony, user_id) -> Any:
+    def find_other_keys_for_user(self, key_ceremony: Any, user_id: str) -> Any:
         return next(
             filter(
                 lambda other_key: other_key["owner_id"] == user_id,
@@ -192,7 +192,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             f"Guardian private data saved to {file}. This data should be carefully protected and never shared."
         )
 
-    def get_ceremony(self, db: Database, id: str) -> dict[str, Any]:
+    def get_ceremony(self, db: Database, id: str) -> Any:
         self.log.debug(f"getting key ceremony {id}")
         key_ceremony = self._key_ceremony_service.get(db, id)
         created_at_utc = key_ceremony["created_at"]

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -1,14 +1,16 @@
 from os import getcwd, path
-from typing import Any
+from typing import Any, List
 import eel
 from pymongo.database import Database
 
 from electionguard import to_file
 from electionguard.election_polynomial import PublicCommitment
-from electionguard.guardian import Guardian
+from electionguard.elgamal import ElGamalPublicKey
+from electionguard.guardian import Guardian, PrivateGuardianRecord
 from electionguard.key_ceremony import CeremonyDetails, ElectionPublicKey
 from electionguard.key_ceremony_mediator import KeyCeremonyMediator
 from electionguard.schnorr import SchnorrProof
+from electionguard.serialize import from_file
 from electionguard.utils import get_optional
 from electionguard_tools.helpers.export import GUARDIAN_PREFIX
 
@@ -58,7 +60,12 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         )
 
     def on_key_ceremony_changed(self, key_ceremony_id: str) -> None:
+        current_user_id = self.auth_service.get_user_id()
+        self.log.debug(
+            f"on_key_ceremony_changed key_ceremony_id: '{key_ceremony_id}', current_user_id: '{current_user_id}'"
+        )
         is_admin = self.auth_service.is_admin()
+        is_guardian = not is_admin
         db = self.db_service.get_db()
         key_ceremony = self.get_ceremony(db, key_ceremony_id)
         guardians_joined_count = len(key_ceremony["guardians_joined"])
@@ -72,16 +79,46 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             self.log.info("all guardians have joined, announcing guardians")
             other_keys = self.announce(key_ceremony)
             self.log.debug("saving other_keys")
-            self._key_ceremony_service.save_other_keys(db, key_ceremony_id, other_keys)
+            self._key_ceremony_service.append_other_key(db, key_ceremony_id, other_keys)
             # this notify_changed occurs inside watch_key_ceremonies and thus may
             #       produce an unnecessary UI refresh for the admin
             self._key_ceremony_service.notify_changed(db, key_ceremony_id)
             # todo #689 wait until all guardians have backups
+
+        # todo: search backups to determine if current user has created backup
+        current_user_backup_exists = False
+        if is_guardian and other_keys_exist and not current_user_backup_exists:
+            self.log.debug("other keys found, creating backup")
+            guardian = self.load_guardian(current_user_id, key_ceremony)
+            self.log.debug("guardian loaded")
+
+            current_user_other_keys = self.find_other_keys_for_user(
+                key_ceremony, current_user_id
+            )
+            for other_key in current_user_other_keys["other_keys"]:
+                other_user = other_key["owner_id"]
+                self.log.debug(
+                    f"saving other_key from {other_user} for {current_user_id}"
+                )
+                public_key = self.recreate_election_public_key(other_key)
+                guardian.save_guardian_key(public_key)
+            guardian.generate_election_partial_key_backups()
+            backups = guardian.share_election_partial_key_backups()
+            self._key_ceremony_service.append_backups(db, key_ceremony_id, backups)
+
         key_ceremony["status"] = get_key_ceremony_status(key_ceremony)
         # pylint: disable=no-member
         eel.refresh_key_ceremony(key_ceremony)
 
-    def announce(self, key_ceremony: Any) -> dict[str, Any]:
+    def find_other_keys_for_user(self, key_ceremony, user_id) -> Any:
+        return next(
+            filter(
+                lambda other_key: other_key["owner_id"] == user_id,
+                key_ceremony["other_keys"],
+            )
+        )
+
+    def announce(self, key_ceremony: Any) -> List[dict[str, Any]]:
         other_keys = []
         quorum = key_ceremony["quorum"]
         guardian_count = key_ceremony["guardian_count"]
@@ -92,26 +129,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         guardians = key_ceremony["guardians_joined"]
         for guardian_id in guardians:
             key = find_key(key_ceremony, guardian_id)
-            coefficient_commitments = [
-                PublicCommitment(x) for x in key["coefficient_commitments"]
-            ]
-            coefficient_proofs = [
-                SchnorrProof(
-                    cp["public_key"],
-                    cp["commitment"],
-                    cp["challenge"],
-                    cp["response"],
-                    cp["usage"],
-                )
-                for cp in key["coefficient_proofs"]
-            ]
-            guardian_public_key = ElectionPublicKey(
-                key["owner_id"],
-                key["sequence_order"],
-                key["key"],
-                coefficient_commitments,
-                coefficient_proofs,
-            )
+            guardian_public_key = self.recreate_election_public_key(key)
             mediator.announce(guardian_public_key)
         for guardian_id in guardians:
             other_guardian_keys = get_optional(
@@ -128,6 +146,29 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             )
         return other_keys
 
+    def recreate_election_public_key(self, key: Any) -> ElectionPublicKey:
+        coefficient_commitments = [
+            PublicCommitment(x) for x in key["coefficient_commitments"]
+        ]
+        coefficient_proofs = [
+            SchnorrProof(
+                cp["public_key"],
+                cp["commitment"],
+                cp["challenge"],
+                cp["response"],
+                cp["usage"],
+            )
+            for cp in key["coefficient_proofs"]
+        ]
+        guardian_public_key = ElectionPublicKey(
+            key["owner_id"],
+            key["sequence_order"],
+            ElGamalPublicKey(key["key"]),
+            coefficient_commitments,
+            coefficient_proofs,
+        )
+        return guardian_public_key
+
     def stop_watching_key_ceremony(self) -> None:
         self._key_ceremony_service.stop_watching()
 
@@ -136,7 +177,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
 
         # append the current user's id to the list of guardians
         user_id = self.auth_service.get_user_id()
-        self._key_ceremony_service.join_key_ceremony(db, key_ceremony_id, user_id)
+        self._key_ceremony_service.append_guardian_joined(db, key_ceremony_id, user_id)
         key_ceremony = self._key_ceremony_service.get(db, key_ceremony_id)
         guardian_number = self._key_ceremony_service.get_guardian_number(
             key_ceremony, user_id
@@ -147,18 +188,28 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         guardian = make_guardian(user_id, guardian_number, key_ceremony)
         self.save_guardian(guardian, key_ceremony)
         public_key = guardian.share_key()
-        self._key_ceremony_service.add_key(db, key_ceremony_id, public_key)
-        # todo #688 Wait until other_keys are created in DB
-
+        self._key_ceremony_service.append_key(db, key_ceremony_id, public_key)
         self.log.debug(
             f"{user_id} joined key ceremony {key_ceremony_id} as guardian #{guardian_number}"
         )
         self._key_ceremony_service.notify_changed(db, key_ceremony_id)
 
+    def load_guardian(self, guardian_id: str, key_ceremony: Any) -> Guardian:
+        file_name = GUARDIAN_PREFIX + guardian_id + ".json"
+        key_ceremony_id = str(key_ceremony["_id"])
+        file_path = path.join(getcwd(), "gui_private_keys", key_ceremony_id, file_name)
+        private_guardian_record = from_file(PrivateGuardianRecord, file_path)
+        return Guardian.from_private_record(
+            private_guardian_record,
+            key_ceremony["guardian_count"],
+            key_ceremony["quorum"],
+        )
+
     def save_guardian(self, guardian: Guardian, key_ceremony: Any) -> None:
         private_guardian_record = guardian.export_private_data()
         file_name = GUARDIAN_PREFIX + private_guardian_record.guardian_id
-        file_path = path.join(getcwd(), "gui_private_keys", str(key_ceremony["_id"]))
+        key_ceremony_id = str(key_ceremony["_id"])
+        file_path = path.join(getcwd(), "gui_private_keys", key_ceremony_id)
         file = to_file(private_guardian_record, file_name, file_path)
         self.log.warn(
             f"Guardian private data saved to {file}. This data should be carefully protected and never shared."

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -10,7 +10,7 @@ from electionguard_gui.components.key_ceremony_details_component import (
 )
 from electionguard_gui.components.setup_election_component import SetupElectionComponent
 from electionguard_gui.main_app import MainApp
-from electionguard_gui.services.authorization_service import AuthoriationService
+from electionguard_gui.services.authorization_service import AuthorizationService
 from electionguard_gui.services.db_service import DbService
 
 from electionguard_gui.services.eel_log_service import EelLogService
@@ -23,7 +23,7 @@ class Container(containers.DeclarativeContainer):
     log_service = providers.Factory(EelLogService)
     db_service = providers.Singleton(DbService, log_service=log_service)
     key_ceremony_service = providers.Factory(KeyCeremonyService, db_service=db_service)
-    authorization_service = providers.Singleton(AuthoriationService)
+    authorization_service = providers.Singleton(AuthorizationService)
 
     # components
     guardian_home_component = providers.Factory(

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -15,6 +15,9 @@ from electionguard_gui.services.db_service import DbService
 
 from electionguard_gui.services.eel_log_service import EelLogService
 from electionguard_gui.services.key_ceremony_service import KeyCeremonyService
+from electionguard_gui.services.key_ceremony_state_service import (
+    KeyCeremonyStateService,
+)
 
 
 class Container(containers.DeclarativeContainer):
@@ -24,6 +27,9 @@ class Container(containers.DeclarativeContainer):
     db_service = providers.Singleton(DbService, log_service=log_service)
     key_ceremony_service = providers.Factory(KeyCeremonyService, db_service=db_service)
     authorization_service = providers.Singleton(AuthorizationService)
+    key_ceremony_state_service = providers.Factory(
+        KeyCeremonyStateService, log_service=log_service
+    )
 
     # components
     guardian_home_component = providers.Factory(
@@ -38,6 +44,7 @@ class Container(containers.DeclarativeContainer):
         KeyCeremonyDetailsComponent,
         key_ceremony_service=key_ceremony_service,
         auth_service=authorization_service,
+        key_ceremony_state_service=key_ceremony_state_service,
     )
     setup_election_component = providers.Factory(SetupElectionComponent)
 
@@ -51,4 +58,5 @@ class Container(containers.DeclarativeContainer):
         key_ceremony_details_component=key_ceremony_details_component,
         setup_election_component=setup_election_component,
         authorization_service=authorization_service,
+        key_ceremony_state_service=key_ceremony_state_service,
     )

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -16,6 +16,9 @@ from electionguard_gui.components.setup_election_component import SetupElectionC
 from electionguard_gui.services.authorization_service import AuthorizationService
 from electionguard_gui.services.db_service import DbService
 from electionguard_gui.services.eel_log_service import EelLogService
+from electionguard_gui.services.key_ceremony_state_service import (
+    KeyCeremonyStateService,
+)
 from electionguard_gui.services.service_base import ServiceBase
 
 
@@ -36,6 +39,7 @@ class MainApp:
         key_ceremony_details_component: KeyCeremonyDetailsComponent,
         setup_election_component: SetupElectionComponent,
         authorization_service: AuthorizationService,
+        key_ceremony_state_service: KeyCeremonyStateService,
     ) -> None:
         super().__init__()
 
@@ -49,7 +53,12 @@ class MainApp:
             setup_election_component,
         ]
 
-        self.services = [authorization_service, log_service, db_service]
+        self.services = [
+            authorization_service,
+            db_service,
+            log_service,
+            key_ceremony_state_service,
+        ]
 
     def start(self) -> None:
         try:

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -13,7 +13,7 @@ from electionguard_gui.components.key_ceremony_details_component import (
 )
 from electionguard_gui.components.setup_election_component import SetupElectionComponent
 
-from electionguard_gui.services.authorization_service import AuthoriationService
+from electionguard_gui.services.authorization_service import AuthorizationService
 from electionguard_gui.services.db_service import DbService
 from electionguard_gui.services.eel_log_service import EelLogService
 from electionguard_gui.services.service_base import ServiceBase
@@ -35,7 +35,7 @@ class MainApp:
         create_key_ceremony_component: CreateKeyCeremonyComponent,
         key_ceremony_details_component: KeyCeremonyDetailsComponent,
         setup_election_component: SetupElectionComponent,
-        authorization_service: AuthoriationService,
+        authorization_service: AuthorizationService,
     ) -> None:
         super().__init__()
 

--- a/src/electionguard_gui/models/key_ceremony_dto.py
+++ b/src/electionguard_gui/models/key_ceremony_dto.py
@@ -1,0 +1,66 @@
+from typing import Any, List
+from datetime import datetime
+from electionguard.key_ceremony import ElectionPublicKey
+
+from electionguard_gui.eel_utils import utc_to_str
+from electionguard_gui.services.db_serialization_service import (
+    dict_to_election_public_key,
+)
+
+# pylint: disable=too-many-instance-attributes
+class KeyCeremonyDto:
+    """A key ceremony for serializing to the front-end GUI and providing helper functions to Python."""
+
+    def __init__(self, key_ceremony: Any):
+        self.id = str(key_ceremony["_id"])
+        self.guardian_count = key_ceremony["guardian_count"]
+        self.key_ceremony_name = key_ceremony["key_ceremony_name"]
+        self.quorum = key_ceremony["quorum"]
+        self.guardians_joined = key_ceremony["guardians_joined"]
+        self.other_keys = key_ceremony["other_keys"]
+        self.backups = key_ceremony["backups"]
+        self.created_by = key_ceremony["created_by"]
+        self.created_at_utc = key_ceremony["created_at"]
+        self.created_at_str = utc_to_str(self.created_at_utc)
+        self.keys = [dict_to_election_public_key(key) for key in key_ceremony["keys"]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "guardian_count": self.guardian_count,
+            "quorum": self.quorum,
+            "key_ceremony_name": self.key_ceremony_name,
+            "status": self.status,
+            "created_by": self.created_by,
+            "created_at_str": self.created_at_str,
+            "guardians_joined": self.guardians_joined,
+            "can_join": self.can_join,
+        }
+
+    id: str
+    guardians_joined: List[str]
+    key_ceremony_name: str
+    created_by: str
+    created_at_utc: datetime
+    can_join: bool
+    keys: List[ElectionPublicKey]
+    guardian_count: int
+    quorum: int
+    other_keys: List[Any]
+    backups: List[Any]
+    status: str
+
+    def find_key(self, guardian_id: str) -> ElectionPublicKey:
+        keys = self.keys
+        return next(key for key in keys if key.owner_id == guardian_id)
+
+    def get_backups_for_user(self, user_id: str) -> List[Any]:
+        return [backup for backup in self.backups if backup["owner_id"] == user_id]
+
+    def find_other_keys_for_user(self, user_id: str) -> Any:
+        return next(
+            filter(
+                lambda other_key: other_key["owner_id"] == user_id,
+                self.other_keys,
+            )
+        )

--- a/src/electionguard_gui/models/key_ceremony_states.py
+++ b/src/electionguard_gui/models/key_ceremony_states.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class KeyCeremonyStates(Enum):
+    """A list of states for the key ceremony."""
+
+    PendingGuardiansJoin = 1
+    PendingAdminAnnounce = 2
+    PendingGuardianBackups = 3
+    PendingAdminToShareBackups = 4
+    PendingGuardiansVerifyBackups = 5
+    PendingAdminToPublishJointKey = 6
+    Complete = 7

--- a/src/electionguard_gui/services/authorization_service.py
+++ b/src/electionguard_gui/services/authorization_service.py
@@ -5,7 +5,7 @@ from electionguard_gui.services.configuration_service import get_is_admin
 from electionguard_gui.services.service_base import ServiceBase
 
 
-class AuthoriationService(ServiceBase):
+class AuthorizationService(ServiceBase):
     """Responsible for functionality related to authorization and user identify"""
 
     # todo: replace state based storage with configparser https://docs.python.org/3/library/configparser.html

--- a/src/electionguard_gui/services/db_serialization_service.py
+++ b/src/electionguard_gui/services/db_serialization_service.py
@@ -1,5 +1,8 @@
 from typing import Any
+from electionguard.election_polynomial import PublicCommitment
+from electionguard.elgamal import ElGamalPublicKey
 from electionguard.key_ceremony import ElectionPartialKeyBackup, ElectionPublicKey
+from electionguard.schnorr import SchnorrProof
 
 
 def public_key_to_dict(key: ElectionPublicKey) -> dict[str, Any]:
@@ -33,3 +36,27 @@ def backup_to_dict(backup: ElectionPartialKeyBackup) -> dict[str, Any]:
             "mac": coordinate.mac,
         },
     }
+
+
+def dict_to_election_public_key(key: Any) -> ElectionPublicKey:
+    coefficient_commitments = [
+        PublicCommitment(x) for x in key["coefficient_commitments"]
+    ]
+    coefficient_proofs = [
+        SchnorrProof(
+            cp["public_key"],
+            cp["commitment"],
+            cp["challenge"],
+            cp["response"],
+            cp["usage"],
+        )
+        for cp in key["coefficient_proofs"]
+    ]
+    guardian_public_key = ElectionPublicKey(
+        key["owner_id"],
+        key["sequence_order"],
+        ElGamalPublicKey(key["key"]),
+        coefficient_commitments,
+        coefficient_proofs,
+    )
+    return guardian_public_key

--- a/src/electionguard_gui/services/db_serialization_service.py
+++ b/src/electionguard_gui/services/db_serialization_service.py
@@ -1,0 +1,35 @@
+from typing import Any
+from electionguard.key_ceremony import ElectionPartialKeyBackup, ElectionPublicKey
+
+
+def public_key_to_dict(key: ElectionPublicKey) -> dict[str, Any]:
+    return {
+        "owner_id": key.owner_id,
+        "sequence_order": key.sequence_order,
+        "key": str(key.key),
+        "coefficient_commitments": [str(c) for c in key.coefficient_commitments],
+        "coefficient_proofs": [
+            {
+                "public_key": str(cp.public_key),
+                "commitment": str(cp.commitment),
+                "challenge": str(cp.challenge),
+                "response": str(cp.response),
+                "usage": str(cp.usage),
+            }
+            for cp in key.coefficient_proofs
+        ],
+    }
+
+
+def backup_to_dict(backup: ElectionPartialKeyBackup) -> dict[str, Any]:
+    coordinate = backup.encrypted_coordinate
+    return {
+        "owner_id": backup.owner_id,
+        "designated_id": backup.designated_id,
+        "designated_sequence_order": backup.designated_sequence_order,
+        "encrypted_coordinate": {
+            "pad": str(coordinate.pad),
+            "data": coordinate.data,
+            "mac": coordinate.mac,
+        },
+    }

--- a/src/electionguard_gui/services/key_ceremony_service.py
+++ b/src/electionguard_gui/services/key_ceremony_service.py
@@ -120,13 +120,3 @@ class KeyCeremonyService(ServiceBase):
             {"_id": ObjectId(key_ceremony_id)},
             {"$push": {"backups": {"$each": backups_dict}}},
         )
-
-
-def get_key_ceremony_status(key_ceremony: Any) -> str:
-    guardians_joined_count = len(key_ceremony["guardians_joined"])
-    guardian_count = key_ceremony["guardian_count"]
-    if guardians_joined_count < guardian_count:
-        return "waiting for guardians"
-    if len(key_ceremony["other_keys"]) == 0:
-        return "waiting for admin to announce guardians"
-    return "waiting for guardians to create backups"

--- a/src/electionguard_gui/services/key_ceremony_service.py
+++ b/src/electionguard_gui/services/key_ceremony_service.py
@@ -1,10 +1,14 @@
 from threading import Event
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional
 from pymongo.database import Database
 from pymongo import CursorType
 from bson import ObjectId
 import eel
-from electionguard.key_ceremony import ElectionPublicKey
+from electionguard.key_ceremony import ElectionPartialKeyBackup, ElectionPublicKey
+from electionguard_gui.services.db_serialization_service import (
+    backup_to_dict,
+    public_key_to_dict,
+)
 from electionguard_gui.services.db_service import DbService
 
 from electionguard_gui.services.service_base import ServiceBase
@@ -83,7 +87,7 @@ class KeyCeremonyService(ServiceBase):
     def get(self, db: Database, id: str) -> Any:
         return db.key_ceremonies.find_one({"_id": ObjectId(id)})
 
-    def join_key_ceremony(
+    def append_guardian_joined(
         self, db: Database, key_ceremony_id: str, guardian_id: str
     ) -> None:
         db.key_ceremonies.update_one(
@@ -91,36 +95,30 @@ class KeyCeremonyService(ServiceBase):
             {"$push": {"guardians_joined": guardian_id}},
         )
 
-    def public_key_to_dict(self, key: ElectionPublicKey) -> Any:
-        return {
-            "owner_id": key.owner_id,
-            "sequence_order": key.sequence_order,
-            "key": str(key.key),
-            "coefficient_commitments": [str(c) for c in key.coefficient_commitments],
-            "coefficient_proofs": [
-                {
-                    "public_key": str(cp.public_key),
-                    "commitment": str(cp.commitment),
-                    "challenge": str(cp.challenge),
-                    "response": str(cp.response),
-                    "usage": str(cp.usage),
-                }
-                for cp in key.coefficient_proofs
-            ],
-        }
-
-    def add_key(
+    def append_key(
         self, db: Database, key_ceremony_id: str, key: ElectionPublicKey
     ) -> None:
         db.key_ceremonies.update_one(
             {"_id": ObjectId(key_ceremony_id)},
-            {"$push": {"keys": self.public_key_to_dict(key)}},
+            {"$push": {"keys": public_key_to_dict(key)}},
         )
 
-    def save_other_keys(self, db: Database, key_ceremony_id: str, keys: Any) -> None:
+    def append_other_key(self, db: Database, key_ceremony_id: str, keys: Any) -> None:
         db.key_ceremonies.update_one(
             {"_id": ObjectId(key_ceremony_id)},
             {"$push": {"other_keys": {"$each": keys}}},
+        )
+
+    def append_backups(
+        self,
+        db: Database,
+        key_ceremony_id: str,
+        backups: List[ElectionPartialKeyBackup],
+    ) -> None:
+        backups_dict = [backup_to_dict(backup) for backup in backups]
+        db.key_ceremonies.update_one(
+            {"_id": ObjectId(key_ceremony_id)},
+            {"$push": {"backups": {"$each": backups_dict}}},
         )
 
 

--- a/src/electionguard_gui/services/key_ceremony_state_service.py
+++ b/src/electionguard_gui/services/key_ceremony_state_service.py
@@ -13,10 +13,10 @@ class KeyCeremonyStateService(ServiceBase):
         self.log = log_service
 
     def get_key_ceremony_state(self, key_ceremony: Any) -> KeyCeremonyStates:
-        guardians_joined = len(key_ceremony["guardians_joined"])
-        guardian_count = key_ceremony["guardian_count"]
-        other_keys = len(key_ceremony["other_keys"])
-        backups = len(key_ceremony["backups"])
+        guardians_joined = len(key_ceremony.guardians_joined)
+        guardian_count = key_ceremony.guardian_count
+        other_keys = len(key_ceremony.other_keys)
+        backups = len(key_ceremony.backups)
         expected_backups = pow(guardian_count, 2)
         self.log.debug(
             f"guardians: {guardians_joined}/{guardian_count}; "
@@ -32,19 +32,16 @@ class KeyCeremonyStateService(ServiceBase):
         return KeyCeremonyStates.PendingAdminToShareBackups
 
 
+status_descriptions = {
+    KeyCeremonyStates.PendingGuardiansJoin: "waiting for guardians",
+    KeyCeremonyStates.PendingAdminAnnounce: "waiting for admin to announce guardians",
+    KeyCeremonyStates.PendingGuardianBackups: "waiting for guardians to create backups",
+    KeyCeremonyStates.PendingAdminToShareBackups: "waiting for admin to share backups",
+    KeyCeremonyStates.PendingGuardiansVerifyBackups: "waiting for guardians to verify backups",
+    KeyCeremonyStates.PendingAdminToPublishJointKey: "waiting for admin to publish the joint key",
+    KeyCeremonyStates.Complete: "key ceremony complete",
+}
+
+
 def get_key_ceremony_status(state: KeyCeremonyStates) -> str:
-    if state == KeyCeremonyStates.PendingGuardiansJoin:
-        return "waiting for guardians"
-    if state == KeyCeremonyStates.PendingAdminAnnounce:
-        return "waiting for admin to announce guardians"
-    if state == KeyCeremonyStates.PendingGuardianBackups:
-        return "waiting for guardians to create backups"
-    if state == KeyCeremonyStates.PendingAdminToShareBackups:
-        return "waiting for admin to share backups"
-    if state == KeyCeremonyStates.PendingGuardiansVerifyBackups:
-        return "waiting for guardians to verify backups"
-    if state == KeyCeremonyStates.PendingAdminToPublishJointKey:
-        return "waiting for admin to publish the joint key"
-    if state == KeyCeremonyStates.Complete:
-        return "key ceremony complete"
-    raise Exception(f"unknown key ceremony state: {state}")
+    return status_descriptions[state]

--- a/src/electionguard_gui/services/key_ceremony_state_service.py
+++ b/src/electionguard_gui/services/key_ceremony_state_service.py
@@ -1,0 +1,50 @@
+from typing import Any
+from electionguard_gui.models.key_ceremony_states import KeyCeremonyStates
+from electionguard_gui.services.eel_log_service import EelLogService
+from electionguard_gui.services.service_base import ServiceBase
+
+
+class KeyCeremonyStateService(ServiceBase):
+    """Responsible for determining the state of the key ceremony"""
+
+    log: EelLogService
+
+    def __init__(self, log_service: EelLogService) -> None:
+        self.log = log_service
+
+    def get_key_ceremony_state(self, key_ceremony: Any) -> KeyCeremonyStates:
+        guardians_joined = len(key_ceremony["guardians_joined"])
+        guardian_count = key_ceremony["guardian_count"]
+        other_keys = len(key_ceremony["other_keys"])
+        backups = len(key_ceremony["backups"])
+        expected_backups = pow(guardian_count, 2)
+        self.log.debug(
+            f"guardians: {guardians_joined}/{guardian_count}; "
+            + f"other_keys: {other_keys}; "
+            + f"backups: {backups}/{expected_backups}"
+        )
+        if guardians_joined < guardian_count:
+            return KeyCeremonyStates.PendingGuardiansJoin
+        if other_keys == 0:
+            return KeyCeremonyStates.PendingAdminAnnounce
+        if backups < expected_backups:
+            return KeyCeremonyStates.PendingGuardianBackups
+        return KeyCeremonyStates.PendingAdminToShareBackups
+
+
+def get_key_ceremony_status(state: KeyCeremonyStates) -> str:
+    if state == KeyCeremonyStates.PendingGuardiansJoin:
+        return "waiting for guardians"
+    if state == KeyCeremonyStates.PendingAdminAnnounce:
+        return "waiting for admin to announce guardians"
+    if state == KeyCeremonyStates.PendingGuardianBackups:
+        return "waiting for guardians to create backups"
+    if state == KeyCeremonyStates.PendingAdminToShareBackups:
+        return "waiting for admin to share backups"
+    if state == KeyCeremonyStates.PendingGuardiansVerifyBackups:
+        return "waiting for guardians to verify backups"
+    if state == KeyCeremonyStates.PendingAdminToPublishJointKey:
+        return "waiting for admin to publish the joint key"
+    if state == KeyCeremonyStates.Complete:
+        return "key ceremony complete"
+    raise Exception(f"unknown key ceremony state: {state}")

--- a/src/electionguard_gui/services/service_base.py
+++ b/src/electionguard_gui/services/service_base.py
@@ -2,7 +2,7 @@ from abc import ABC
 
 
 class ServiceBase(ABC):
-    """Responsible for common functionality among ell components"""
+    """Responsible for common functionality among services"""
 
     def init(self) -> None:
         self.expose()


### PR DESCRIPTION
### Issue

Fixes #688 

### Description
In the GUI once the admin has announced the guardians and shared their public "other" keys, the guardians will now use those other keys to create backups and place them in the database.  This additionally starts to refactor the exceedingly long and complicated KeyCeremonyDetailsComponent by moving logic into other services such as a new KeyCeremonyStateService that will be expanded in subsequent PR's.

Note: This PR is stacked on PR #707 please retarget this to main prior to merging.

### Testing
1. Have an admin create a key ceremony in the GUI
2. Have all guardians log in

Expected: the UI should finish in a state that looks like this:

![image](https://user-images.githubusercontent.com/1769905/179614934-fd1f5fd5-7dc6-45aa-bee2-5ffe2d2873a3.png)
