### PR TITLE
#726 support more ballots in GUI

### DIFF
--- a/src/electionguard_gui/components/upload_ballots_component.py
+++ b/src/electionguard_gui/components/upload_ballots_component.py
@@ -60,13 +60,17 @@ class UploadBallotsComponent(ComponentBase):
             return self.handle_error(e)
 
     def upload_ballot(
-        self, ballot_upload_id: str, file_name: str, file_contents: str
+        self,
+        ballot_upload_id: str,
+        election_id: str,
+        file_name: str,
+        file_contents: str,
     ) -> dict[str, Any]:
         try:
             db = self._db_service.get_db()
             self._log.debug(f"adding ballot {file_name} to {ballot_upload_id}")
             self._ballot_upload_service.add_ballot(
-                db, ballot_upload_id, file_name, file_contents
+                db, ballot_upload_id, election_id, file_name, file_contents
             )
             return eel_success()
         # pylint: disable=broad-except

--- a/src/electionguard_gui/models/decryption_dto.py
+++ b/src/electionguard_gui/models/decryption_dto.py
@@ -80,7 +80,9 @@ class DecryptionDto:
 
     def get_status(self) -> str:
         if len(self.guardians_joined) < self.guardians:
-            return "waiting for guardians"
+            return "waiting for all guardians to join"
+        if self.completed_at_str is None:
+            return "performing decryption"
         return "decryption complete"
 
     def to_id_name_dict(self) -> dict[str, Any]:

--- a/src/electionguard_gui/services/ballot_upload_service.py
+++ b/src/electionguard_gui/services/ballot_upload_service.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from bson import ObjectId
 from pymongo.database import Database
 from electionguard.ballot import SubmittedBallot
 from electionguard.serialize import from_raw
@@ -34,7 +33,6 @@ class BallotUploadService(ServiceBase):
             "device_file_name": device_file_name,
             "device_file_contents": device_file_contents,
             "ballot_count": ballot_count,
-            "ballots": [],
             "created_by": self._auth_service.get_user_id(),
             "created_at": created_at,
         }
@@ -46,26 +44,28 @@ class BallotUploadService(ServiceBase):
         self,
         db: Database,
         ballot_upload_id: str,
+        election_id: str,
         file_name: str,
         file_contents: str,
     ) -> None:
         self._log.trace(f"adding ballot {file_name} to {ballot_upload_id}")
-        db.ballot_uploads.update_one(
-            {"_id": ObjectId(ballot_upload_id)},
+        db.ballot_uploads.insert_one(
             {
-                "$push": {
-                    "ballots": {"file_name": file_name, "file_contents": file_contents}
-                }
-            },
+                "ballot_upload_id": ballot_upload_id,
+                "election_id": election_id,
+                "file_name": file_name,
+                "file_contents": file_contents,
+            }
         )
 
     def get_ballots(self, db: Database, election_id: str) -> list[SubmittedBallot]:
         self._log.trace(f"getting ballots for {election_id}")
-        ballot_uploads = db.ballot_uploads.find({"election_id": election_id})
+        ballot_uploads = db.ballot_uploads.find(
+            {"election_id": election_id, "file_contents": {"$exists": True}}
+        )
         ballots = []
-        for ballot_upload in ballot_uploads:
-            for ballot_obj in ballot_upload["ballots"]:
-                ballot_str = ballot_obj["file_contents"]
-                ballot = from_raw(SubmittedBallot, ballot_str)
-                ballots.append(ballot)
+        for ballot_obj in ballot_uploads:
+            ballot_str = ballot_obj["file_contents"]
+            ballot = from_raw(SubmittedBallot, ballot_str)
+            ballots.append(ballot)
         return ballots

--- a/src/electionguard_gui/web/components/admin/upload-ballots-component.js
+++ b/src/electionguard_gui/web/components/admin/upload-ballots-component.js
@@ -62,6 +62,7 @@ export default {
         console.log("Uploading ballot", ballotFile.name);
         const result = await eel.upload_ballot(
           uploadId,
+          this.electionId,
           ballotFile.name,
           ballotContents
         )();


### PR DESCRIPTION
### Issue

Fixes #726 

### Description
This splits out uploaded ballots into smaller records in mongo.

### Testing
Upload more than ~20 ballots in the GUI, it should work.