### PR TITLE
Add the missing parameter

### DIFF
--- a/src/electionguard_gui/web/components/guardian/view-decryption-guardian-component.js
+++ b/src/electionguard_gui/web/components/guardian/view-decryption-guardian-component.js
@@ -33,7 +33,7 @@ export default {
     refresh_decryption: async function () {
       console.log("refreshing decryption");
       this.loading = true;
-      const result = await eel.get_decryption(this.decryptionId)();
+      const result = await eel.get_decryption(this.decryptionId, true)();
       this.error = !result.success;
       if (result.success) {
         this.decryption = result.result;


### PR DESCRIPTION
### Issue

Fixes #729 

### Description
Added the missing parameter so that it will not throw an exception as well as refresh the decryption when it loads it.

