### PR TITLE
Reuse guardians rather than recreating them during election creation

### DIFF
--- a/src/electionguard_gui/components/create_election_component.py
+++ b/src/electionguard_gui/components/create_election_component.py
@@ -16,6 +16,7 @@ from electionguard_gui.services import (
     KeyCeremonyService,
     GuiSetupInputRetrievalStep,
     ElectionService,
+    GuardianService,
 )
 
 
@@ -29,6 +30,7 @@ class CreateElectionComponent(ComponentBase):
     _setup_election_builder_step: SetupElectionBuilderStep
     _election_service: ElectionService
     _output_setup_files_step: OutputSetupFilesStep
+    _guardian_service: GuardianService
 
     def __init__(
         self,
@@ -37,12 +39,14 @@ class CreateElectionComponent(ComponentBase):
         setup_input_retrieval_step: GuiSetupInputRetrievalStep,
         setup_election_builder_step: SetupElectionBuilderStep,
         output_setup_files_step: OutputSetupFilesStep,
+        guardian_service: GuardianService,
     ) -> None:
         self._key_ceremony_service = key_ceremony_service
         self._setup_input_retrieval_step = setup_input_retrieval_step
         self._setup_election_builder_step = setup_election_builder_step
         self._election_service = election_service
         self._output_setup_files_step = output_setup_files_step
+        self._guardian_service = guardian_service
 
     def expose(self) -> None:
         eel.expose(self.get_keys)
@@ -74,8 +78,18 @@ class CreateElectionComponent(ComponentBase):
 
             key_ceremony = self._key_ceremony_service.get(db, key_ceremony_id)
 
+            guardians = [
+                self._guardian_service.load_guardian_from_key_ceremony(
+                    "user" + str(i), key_ceremony
+                )
+                for i in range(1, key_ceremony.guardian_count + 1)
+            ]
             election_inputs = self._setup_input_retrieval_step.get_gui_inputs(
-                key_ceremony.guardian_count, key_ceremony.quorum, url, manifest_raw
+                key_ceremony.guardian_count,
+                key_ceremony.quorum,
+                guardians,
+                url,
+                manifest_raw,
             )
             joint_key = key_ceremony.get_joint_key()
             build_election_results = (

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -201,6 +201,7 @@ class Container(containers.DeclarativeContainer):
         setup_election_builder_step=setup_election_builder_step,
         setup_input_retrieval_step=setup_input_retrieval_step,
         output_setup_files_step=output_setup_files_step,
+        guardian_service=guardian_service,
     )
     create_key_ceremony_component: Factory[
         CreateKeyCeremonyComponent

--- a/src/electionguard_gui/services/gui_setup_input_retrieval_step.py
+++ b/src/electionguard_gui/services/gui_setup_input_retrieval_step.py
@@ -1,9 +1,8 @@
 from typing import Optional
 from electionguard import Manifest
-from electionguard.key_ceremony import CeremonyDetails
+from electionguard.guardian import Guardian
 from electionguard_cli import SetupInputs
 from electionguard_cli.setup_election import SetupInputRetrievalStep
-from electionguard_tools import KeyCeremonyOrchestrator
 
 
 class GuiSetupInputRetrievalStep(SetupInputRetrievalStep):
@@ -13,14 +12,12 @@ class GuiSetupInputRetrievalStep(SetupInputRetrievalStep):
         self,
         guardian_count: int,
         quorum: int,
+        guardians: list[Guardian],
         verification_url: Optional[str],
         manifest_raw: str,
     ) -> SetupInputs:
 
         self.print_header("Retrieving Inputs")
-        guardians = KeyCeremonyOrchestrator.create_guardians(
-            CeremonyDetails(guardian_count, quorum)
-        )
         manifest: Manifest = self._get_manifest_raw(manifest_raw)
         return SetupInputs(
             guardian_count, quorum, guardians, manifest, verification_url, force=True


### PR DESCRIPTION
### Issue

Fixes #731 

### Description
This reuses the guardians data from the key ceremony rather than creating new guardians during election creation.

### Testing
Run an end-to-end test and validate it with the Mitre verifier.  There should be no problem with the public key.