### PR TITLE
#739 Logging

### DIFF
--- a/src/electionguard/logs.py
+++ b/src/electionguard/logs.py
@@ -115,7 +115,7 @@ def get_stream_handler(log_level: int) -> logging.StreamHandler:
     return stream_handler
 
 
-def get_file_handler() -> logging.FileHandler:
+def get_file_handler(log_level: int, filename: str) -> logging.FileHandler:
     """
     Get a File System Handler, sends verbose logging to a file, `electionguard.log`.
     When that file gets too large, the logs will rotate, creating files with names
@@ -125,9 +125,9 @@ def get_file_handler() -> logging.FileHandler:
     # TODO: add file compression, save a bunch of space.
     #   https://medium.com/@rahulraghu94/overriding-pythons-timedrotatingfilehandler-to-compress-your-log-files-iot-c766a4ace240 # pylint: disable=line-too-long
     file_handler = RotatingFileHandler(
-        "electionguard.log", "a", maxBytes=10_000_000, backupCount=10
+        filename, "a", maxBytes=10_000_000, backupCount=10
     )
-    file_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(log_level)
     file_handler.setFormatter(logging.Formatter(FORMAT))
     return file_handler
 

--- a/src/electionguard_gui/Dockerfile
+++ b/src/electionguard_gui/Dockerfile
@@ -59,16 +59,16 @@ RUN poetry config virtualenvs.in-project true && \
 # Get Source
 ##################################################################################
 
+# cleanup first, the next layer will get invalidated easiliy
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY ./src ./src
 RUN rm src/electionguard_gui/__init__.py
 
 ##################################################################################
 # Run EGUI
 ##################################################################################
-
-# cleanup
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 # the final poetry install runs fast, it activates the virtualenv and initializes the modules
 RUN poetry install

--- a/src/electionguard_gui/components/component_base.py
+++ b/src/electionguard_gui/components/component_base.py
@@ -27,6 +27,6 @@ class ComponentBase(ABC):
         fact that method names exposed must be globally unique."""
 
     def handle_error(self, error: Exception) -> dict[str, Any]:
-        self._log.error(error)
+        self._log.error("error in component_base", error)
         traceback.print_exc()
         return eel_fail(str(error))

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -109,7 +109,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             eel.refresh_key_ceremony(eel_success(result))
         # pylint: disable=broad-except
         except Exception as e:
-            self._log.error(e)
+            self._log.error("error on key ceremony changed", e)
             traceback.print_exc()
             # pylint: disable=no-member
             eel.refresh_key_ceremony(eel_fail(str(e)))

--- a/src/electionguard_gui/components/view_decryption_component.py
+++ b/src/electionguard_gui/components/view_decryption_component.py
@@ -65,7 +65,7 @@ class ViewDecryptionComponent(ComponentBase):
             refresh_decryption(eel_success())
         # pylint: disable=broad-except
         except Exception as e:
-            self._log.error(e)
+            self._log.error("error in on decryption changed", e)
             traceback.print_exc()
             refresh_decryption(eel_fail(str(e)))
 

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -54,7 +54,7 @@ class Container(containers.DeclarativeContainer):
     """Responsible for dependency injection and how components are wired together"""
 
     # services
-    log_service: Factory[EelLogService] = providers.Factory(EelLogService)
+    log_service: Factory[EelLogService] = providers.Singleton(EelLogService)
     config_service: Factory[ConfigurationService] = providers.Factory(
         ConfigurationService
     )

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -54,7 +54,7 @@ class Container(containers.DeclarativeContainer):
     """Responsible for dependency injection and how components are wired together"""
 
     # services
-    log_service: Factory[EelLogService] = providers.Singleton(EelLogService)
+    log_service: Singleton[EelLogService] = providers.Singleton(EelLogService)
     config_service: Factory[ConfigurationService] = providers.Factory(
         ConfigurationService
     )

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -103,6 +103,6 @@ class MainApp:
             self.log_service.debug(f"Starting eel port={port} mode={mode} host={host}")
             eel.start("index.html", size=(1024, 768), port=port, mode=mode, host=host)
         except Exception as e:
-            self.log_service.error(e)
+            self.log_service.error("error in main app start", e)
             traceback.print_exc()
             raise e

--- a/src/electionguard_gui/services/ballot_upload_service.py
+++ b/src/electionguard_gui/services/ballot_upload_service.py
@@ -59,13 +59,18 @@ class BallotUploadService(ServiceBase):
         )
 
     def get_ballots(self, db: Database, election_id: str) -> list[SubmittedBallot]:
-        self._log.trace(f"getting ballots for {election_id}")
+        self._log.debug(f"getting ballots for {election_id}")
         ballot_uploads = db.ballot_uploads.find(
             {"election_id": election_id, "file_contents": {"$exists": True}}
         )
         ballots = []
         for ballot_obj in ballot_uploads:
             ballot_str = ballot_obj["file_contents"]
-            ballot = from_raw(SubmittedBallot, ballot_str)
+            try:
+                ballot = from_raw(SubmittedBallot, ballot_str)
+            except Exception as e:
+                self._log.info(f"error deserializing ballot: {ballot_obj}")
+                self._log.error(e)
+                raise
             ballots.append(ballot)
         return ballots

--- a/src/electionguard_gui/services/ballot_upload_service.py
+++ b/src/electionguard_gui/services/ballot_upload_service.py
@@ -68,9 +68,9 @@ class BallotUploadService(ServiceBase):
             ballot_str = ballot_obj["file_contents"]
             try:
                 ballot = from_raw(SubmittedBallot, ballot_str)
+            # pylint: disable=broad-except
             except Exception as e:
-                self._log.info(f"error deserializing ballot: {ballot_obj}")
-                self._log.error(e)
-                raise
+                self._log.error("error deserializing ballot: {ballot_obj}", e)
+                # per RC 8/15/22 log errors and continue processing even if it makes numbers incorrect
             ballots.append(ballot)
         return ballots

--- a/src/electionguard_gui/services/ballot_upload_service.py
+++ b/src/electionguard_gui/services/ballot_upload_service.py
@@ -68,9 +68,9 @@ class BallotUploadService(ServiceBase):
             ballot_str = ballot_obj["file_contents"]
             try:
                 ballot = from_raw(SubmittedBallot, ballot_str)
+                ballots.append(ballot)
             # pylint: disable=broad-except
             except Exception as e:
                 self._log.error("error deserializing ballot: {ballot_obj}", e)
                 # per RC 8/15/22 log errors and continue processing even if it makes numbers incorrect
-            ballots.append(ballot)
         return ballots

--- a/src/electionguard_gui/services/eel_log_service.py
+++ b/src/electionguard_gui/services/eel_log_service.py
@@ -43,9 +43,17 @@ class EelLogService(ServiceBase):
         log_warning(message, *args, **kwargs)
 
     # pylint: disable=no-self-use
-    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
-        log_error(message, *args, **kwargs)
+    def error(self, message: str, exception: Exception) -> None:
+        log_error(
+            f"{message} '{exception}'",
+            exc_info=1,
+            extra={"exception": exception},
+        )
 
     # pylint: disable=no-self-use
-    def fatal(self, message: str, *args: Any, **kwargs: Any) -> None:
-        log_critical(message, *args, **kwargs)
+    def fatal(self, message: str, exception: Exception) -> None:
+        log_critical(
+            f"{message} '{str(exception)}'",
+            exc_info=1,
+            extra={"exception": exception},
+        )

--- a/src/electionguard_gui/services/eel_log_service.py
+++ b/src/electionguard_gui/services/eel_log_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 from os import path, makedirs
 from typing import Any
@@ -22,7 +23,8 @@ class EelLogService(ServiceBase):
         LOG.set_stream_log_level(logging.DEBUG)
         file_dir = path.join(get_data_dir(), "logs")
         makedirs(file_dir, exist_ok=True)
-        file_name = path.join(file_dir, "electionguard.log")
+        now = datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+        file_name = path.join(file_dir, f"electionguard-{now}.log")
         LOG.add_handler(get_file_handler(logging.DEBUG, file_name))
 
     def trace(self, message: str, *args: Any, **kwargs: Any) -> None:

--- a/src/electionguard_gui/services/eel_log_service.py
+++ b/src/electionguard_gui/services/eel_log_service.py
@@ -1,4 +1,13 @@
-from datetime import datetime
+import logging
+from typing import Any
+from electionguard.logs import (
+    log_critical,
+    log_debug,
+    log_error,
+    log_info,
+    log_warning,
+    LOG,
+)
 from electionguard_gui.services.service_base import ServiceBase
 
 
@@ -6,24 +15,28 @@ class EelLogService(ServiceBase):
     """A facade for logging. Currently this simply writes to the console without using log levels, but
     this may eventually be used to log to a file or database."""
 
-    # pylint: disable=no-self-use
-    def _log(self, level: str, message: str) -> None:
-        print(f"{datetime.now()} {level} {message}")
+    def __init__(self) -> None:
+        LOG.set_stream_log_level(logging.DEBUG)
 
-    def trace(self, message: str) -> None:
+    def trace(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
 
-    def debug(self, message: str) -> None:
-        self._log("DEBUG", message)
+    # pylint: disable=no-self-use
+    def debug(self, message: str, *args: Any, **kwargs: Any) -> None:
+        log_debug(message, *args, **kwargs)
 
-    def info(self, message: str) -> None:
-        self._log("INFO ", message)
+    # pylint: disable=no-self-use
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        log_info(message, *args, **kwargs)
 
-    def warn(self, message: str) -> None:
-        self._log("WARN ", message)
+    # pylint: disable=no-self-use
+    def warn(self, message: str, *args: Any, **kwargs: Any) -> None:
+        log_warning(message, *args, **kwargs)
 
-    def error(self, e: Exception) -> None:
-        self._log("ERROR", str(e))
+    # pylint: disable=no-self-use
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        log_error(message, *args, **kwargs)
 
-    def fatal(self, message: str) -> None:
-        self._log("FATAL", message)
+    # pylint: disable=no-self-use
+    def fatal(self, message: str, *args: Any, **kwargs: Any) -> None:
+        log_critical(message, *args, **kwargs)

--- a/src/electionguard_gui/services/eel_log_service.py
+++ b/src/electionguard_gui/services/eel_log_service.py
@@ -1,6 +1,8 @@
 import logging
+from os import path, makedirs
 from typing import Any
 from electionguard.logs import (
+    get_file_handler,
     log_critical,
     log_debug,
     log_error,
@@ -8,6 +10,7 @@ from electionguard.logs import (
     log_warning,
     LOG,
 )
+from electionguard_gui.services.directory_service import get_data_dir
 from electionguard_gui.services.service_base import ServiceBase
 
 
@@ -17,6 +20,10 @@ class EelLogService(ServiceBase):
 
     def __init__(self) -> None:
         LOG.set_stream_log_level(logging.DEBUG)
+        file_dir = path.join(get_data_dir(), "logs")
+        makedirs(file_dir, exist_ok=True)
+        file_name = path.join(file_dir, "electionguard.log")
+        LOG.add_handler(get_file_handler(logging.DEBUG, file_name))
 
     def trace(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass

--- a/tests/unit/electionguard/test_logs.py
+++ b/tests/unit/electionguard/test_logs.py
@@ -1,3 +1,4 @@
+import logging
 from tests.base_test_case import BaseTestCase
 
 from electionguard.logs import (
@@ -45,7 +46,7 @@ class TestLogs(BaseTestCase):
         self.assertEqual(len(empty_handlers), 0)
 
         # Act
-        log_add_handler(get_stream_handler())
+        log_add_handler(get_stream_handler(logging.INFO))
         added_handlers = log_handlers()
 
         # Assert


### PR DESCRIPTION
### Issue

Supports #739

### Description
Couldn't repro the 739 bug, so this adds several features that will help us if it occurs again:

* If an error occurs during ballot decryption the system will now log it as an error and continue processing
* This updates GUI logging to combine it with the regular EG logging
* This updates GUI logging to send logs to the filesystem

### Testing
Run the GUI, you should see file system logs at `egui_mnt\data\logs`