### PR TITLE
#743 Fix Guardian ids in Lagrange Coefficients

### DIFF
--- a/src/electionguard_gui/models/election_dto.py
+++ b/src/electionguard_gui/models/election_dto.py
@@ -105,6 +105,12 @@ class ElectionDto:
             raise Exception("No guardian records found")
         return from_list_raw(GuardianRecord, self.guardian_records)
 
+    def get_guardian_sequence_order(self, guardian_id: str) -> int:
+        for record in self.get_guardian_records():
+            if record.guardian_id == guardian_id:
+                return record.sequence_order
+        raise Exception("Guardian not found")
+
 
 def _get_list(election: dict[str, Any], name: str) -> list:
     value = election.get(name)

--- a/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
+++ b/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
@@ -33,6 +33,8 @@ class DecryptionS2AnnounceService(DecryptionStageBase):
             guardian_sequence_number = election.get_guardian_sequence_order(
                 decryption_share_dict.guardian_id
             )
+            # coefficients will fail validation unless the key is a numeric encoded
+            #       string of the guardian's sequence number
             decryption_share_dict.guardian_key.owner_id = str(guardian_sequence_number)
             decryption_mediator.announce(
                 decryption_share_dict.guardian_key,

--- a/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
+++ b/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
@@ -28,16 +28,17 @@ class DecryptionS2AnnounceService(DecryptionStageBase):
             context,
         )
         decryption_shares = decryption.get_decryption_shares()
-        i = 1
         for decryption_share_dict in decryption_shares:
             self._log.debug(f"announcing {decryption_share_dict.guardian_id}")
-            decryption_share_dict.guardian_key.owner_id = str(i)
+            guardian_sequence_number = election.get_guardian_sequence_order(
+                decryption_share_dict.guardian_id
+            )
+            decryption_share_dict.guardian_key.owner_id = str(guardian_sequence_number)
             decryption_mediator.announce(
                 decryption_share_dict.guardian_key,
                 decryption_share_dict.tally_share,
                 decryption_share_dict.ballot_shares,
             )
-            i += 1
 
         manifest = election.get_manifest()
         ballots = self._ballot_upload_service.get_ballots(db, election.id)

--- a/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
+++ b/src/electionguard_gui/services/decryption_stages/decryption_s2_announce_service.py
@@ -28,13 +28,16 @@ class DecryptionS2AnnounceService(DecryptionStageBase):
             context,
         )
         decryption_shares = decryption.get_decryption_shares()
+        i = 1
         for decryption_share_dict in decryption_shares:
             self._log.debug(f"announcing {decryption_share_dict.guardian_id}")
+            decryption_share_dict.guardian_key.owner_id = str(i)
             decryption_mediator.announce(
                 decryption_share_dict.guardian_key,
                 decryption_share_dict.tally_share,
                 decryption_share_dict.ballot_shares,
             )
+            i += 1
 
         manifest = election.get_manifest()
         ballots = self._ballot_upload_service.get_ballots(db, election.id)


### PR DESCRIPTION
### Issue

Fixes #743 

### Description
Guardians previously needed to be named with numbers else the election verification would fail when validating the Lagrange Coefficients stating that the guardian_id needed to be numeric.  This fixes it by having the admin look up the guardian's sequence order and announcing guardians with that value instead of the guardian's alpha-numeric identifier.

### Testing
Run an end-to-end election with guardians with alpha-numeric strings and validate it in Julia.  Expected: it should validate.