### PR TITLE
Decrypt Perf Improvement - Remove low level logging

### DIFF
--- a/src/electionguard/manifest.py
+++ b/src/electionguard/manifest.py
@@ -121,7 +121,6 @@ class AnnotatedString(CryptoHashable):
         A hash representation of the object
         """
         hash = hash_elems(self.annotation, self.value)
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -151,7 +150,6 @@ class Language(CryptoHashable):
         A hash representation of the object
         """
         hash = hash_elems(self.value, self.language)
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -178,7 +176,6 @@ class InternationalizedText(CryptoHashable):
         A hash representation of the object
         """
         hash = hash_elems(self.text)
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -214,7 +211,6 @@ class ContactInformation(CryptoHashable):
         A hash representation of the object
         """
         hash = hash_elems(self.name, self.address_line, self.email, self.phone)
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -237,7 +233,6 @@ class GeopoliticalUnit(ElectionObjectBase, CryptoHashable):
         hash = hash_elems(
             self.object_id, self.name, str(self.type.name), self.contact_information
         )
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -258,7 +253,6 @@ class BallotStyle(ElectionObjectBase, CryptoHashable):
         hash = hash_elems(
             self.object_id, self.geopolitical_unit_ids, self.party_ids, self.image_uri
         )
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -291,7 +285,6 @@ class Party(ElectionObjectBase, CryptoHashable):
             self.color,
             self.logo_uri,
         )
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -323,7 +316,6 @@ class Candidate(ElectionObjectBase, CryptoHashable):
         A hash representation of the object
         """
         hash = hash_elems(self.object_id, self.name, self.party_id, self.image_uri)
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
 
@@ -426,7 +418,6 @@ class ContestDescription(OrderedObjectBase, CryptoHashable):
             self.votes_allowed,
             self.ballot_selections,
         )
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
     def is_valid(self) -> bool:
@@ -674,7 +665,6 @@ class Manifest(CryptoHashable):
             self.contests,
             self.ballot_styles,
         )
-        log_debug(f"{self.__class__} : crypto_hash: {hash.to_hex()}")
         return hash
 
     def is_valid(self) -> bool:


### PR DESCRIPTION
### Issue

Fixes #751 

### Description
Removing the low-level logging improves performance by 31% (from 20.7 seconds to 15.5).  Here's perf before for 10 ballots:

```
20.76447 decryption_s2_announce_service.py - run() - get_tally
  0.71651 decryption_stage_base.py - get_tally() - init CiphertextTally
  18.97710 decryption_stage_base.py - get_tally() - batch_append
    18.56782 tally.py - batch_append() - cast_ballot_selections loop
      18.56729 tally.py - batch_append() - should collect
        3.29177 ballot_validator.py - ballot_is_valid_for_election() - ballot_is_valid_for_style
        15.27533 ballot_validator.py - ballot_is_valid_for_election() - is_valid_encryption
          0.00004 ballot.py - is_valid_encryption() - mismatching ballot hash
          0.00112 ballot.py - is_valid_encryption() - mismatching crypto hash
          14.07134 ballot.py - is_valid_encryption() - selection.is_valid_encryption
              0.06838 ballot.py - CiphertextBallotSelection.is_valid_encryption() - crypto_hash_with
              13.99847 ballot.py - CiphertextBallotSelection.is_valid_encryption() - self.proof.is_valid
                5.63019 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - is_valid_residue
                0.00996 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - is_in_bounds
                0.04931 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - hash_elems
                1.85079 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gv0
                1.84584 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gv1
                1.83126 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - kv0
                2.76879 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gc1kv1
          1.20081 ballot.py - is_valid_encryption() - contest.is_valid_encryption
      0.00049 tally.py - batch_append() - collect selections
      0.00000 tally.py - batch_append() - _add_spoiled
    0.29982 tally.py - batch_append() - _execute_accumulate
1.89620 decryption_s2_announce_service.py - run() - get_plaintext_tally
  0.00000 decryption_mediator.py - get_plaintext_tally() - Initial checks
  1.89620 decryption_mediator.py - get_plaintext_tally() - decrypt_tally
    0.00001 decrypt_with_shares.py - decrypt_tally() - Enumerate contests
    0.00008 decrypt_with_shares.py - decrypt_tally() - Initialize contest
    1.89603 decrypt_with_shares.py - decrypt_tally() - decrypt_contest_with_decryption_shares
      0.00383 decrypt_with_shares.py - decrypt_contest_with_decryption_shares() - get_shares_for_selection
      1.89162 decrypt_with_shares.py - decrypt_contest_with_decryption_shares() - decrypt_selection_with_decryption_shares
```

And here's perf after:

```
14.14230 decryption_s2_announce_service.py - run() - get_tally
  0.00942 decryption_stage_base.py - get_tally() - init CiphertextTally
  14.11816 decryption_stage_base.py - get_tally() - batch_append
    13.80853 tally.py - batch_append() - cast_ballot_selections loop
      13.80797 tally.py - batch_append() - should collect
        0.06748 ballot_validator.py - ballot_is_valid_for_election() - ballot_is_valid_for_style
        13.74033 ballot_validator.py - ballot_is_valid_for_election() - is_valid_encryption
          0.00002 ballot.py - is_valid_encryption() - mismatching ballot hash
          0.00043 ballot.py - is_valid_encryption() - mismatching crypto hash
          12.66011 ballot.py - is_valid_encryption() - selection.is_valid_encryption
              0.06060 ballot.py - CiphertextBallotSelection.is_valid_encryption() - crypto_hash_with
              12.59547 ballot.py - CiphertextBallotSelection.is_valid_encryption() - self.proof.is_valid
                5.06581 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - is_valid_residue
                0.00845 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - is_in_bounds
                0.04189 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - hash_elems
                1.65926 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gv0
                1.65569 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gv1
                1.65098 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - kv0
                2.50196 chaum_pedersen.py - DisjunctiveChaumPedersonProof.is_valid() - gc1kv1
          1.07796 ballot.py - is_valid_encryption() - contest.is_valid_encryption
      0.00052 tally.py - batch_append() - collect selections
      0.00001 tally.py - batch_append() - _add_spoiled
    0.22696 tally.py - batch_append() - _execute_accumulate
1.70704 decryption_s2_announce_service.py - run() - get_plaintext_tally
  0.00001 decryption_mediator.py - get_plaintext_tally() - Initial checks
  1.70703 decryption_mediator.py - get_plaintext_tally() - decrypt_tally
    0.00001 decrypt_with_shares.py - decrypt_tally() - Enumerate contests
    0.00009 decrypt_with_shares.py - decrypt_tally() - Initialize contest
    1.70686 decrypt_with_shares.py - decrypt_tally() - decrypt_contest_with_decryption_shares
      0.00331 decrypt_with_shares.py - decrypt_contest_with_decryption_shares() - get_shares_for_selection
      1.70299 decrypt_with_shares.py - decrypt_contest_with_decryption_shares() - decrypt_selection_with_decryption_shares
```

### Testing
Run a tally before and after this change, it should be ~25% faster.