### PR TITLE
#764 Stop Removing Duplicate Contests in Report

### DIFF
--- a/src/electionguard_gui/services/plaintext_ballot_service.py
+++ b/src/electionguard_gui/services/plaintext_ballot_service.py
@@ -7,7 +7,7 @@ from electionguard_gui.models.election_dto import ElectionDto
 
 def get_plaintext_ballot_report(
     election: ElectionDto, plaintext_ballot: PlaintextTally
-) -> dict[str, Any]:
+) -> list:
     manifest = election.get_manifest()
     selection_names = manifest.get_selection_names("en")
     contest_names = manifest.get_contest_names()

--- a/src/electionguard_gui/services/plaintext_ballot_service.py
+++ b/src/electionguard_gui/services/plaintext_ballot_service.py
@@ -25,8 +25,8 @@ def _get_tally_report(
     contest_names: dict[str, str],
     selection_write_ins: dict[str, bool],
     parties: dict[str, str],
-) -> dict[str, Any]:
-    tally_report = {}
+) -> list:
+    tally_report = []
     contests = plaintext_ballot.contests.values()
     for tally_contest in contests:
         selections = list(tally_contest.selections.values())
@@ -34,7 +34,12 @@ def _get_tally_report(
             selections, selection_names, selection_write_ins, parties
         )
         contest_name = contest_names.get(tally_contest.object_id, "n/a")
-        tally_report[contest_name] = contest_details
+        tally_report.append(
+            {
+                "name": contest_name,
+                "details": contest_details,
+            }
+        )
     return tally_report
 
 

--- a/src/electionguard_gui/services/plaintext_ballot_service.py
+++ b/src/electionguard_gui/services/plaintext_ballot_service.py
@@ -13,6 +13,19 @@ def get_plaintext_ballot_report(
     contest_names = manifest.get_contest_names()
     selection_write_ins = _get_candidate_write_ins(manifest)
     parties = _get_selection_parties(manifest)
+    tally_report = _get_tally_report(
+        plaintext_ballot, selection_names, contest_names, selection_write_ins, parties
+    )
+    return tally_report
+
+
+def _get_tally_report(
+    plaintext_ballot: PlaintextTally,
+    selection_names: dict[str, str],
+    contest_names: dict[str, str],
+    selection_write_ins: dict[str, bool],
+    parties: dict[str, str],
+) -> dict[str, Any]:
     tally_report = {}
     contests = plaintext_ballot.contests.values()
     for tally_contest in contests:

--- a/src/electionguard_gui/web/components/shared/view-plaintext-ballot-component.js
+++ b/src/electionguard_gui/web/components/shared/view-plaintext-ballot-component.js
@@ -3,8 +3,8 @@ export default {
     ballot: Object,
   },
   template: /*html*/ `
-    <div v-for="(contestContents, contestName) in ballot" class="mb-5">
-      <h2>{{contestName}}</h2>
+    <div v-for="contest in ballot" class="mb-5">
+      <h2>{{contest.name}}</h2>
       <table class="table table-striped">
         <thead>
           <tr>
@@ -15,7 +15,7 @@ export default {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="contestInfo in contestContents.selections">
+          <tr v-for="contestInfo in contest.details.selections">
             <td>{{contestInfo.name}}</td>
             <td>{{contestInfo.party}}</td>
             <td class="text-end">{{contestInfo.tally}}</td>
@@ -24,13 +24,13 @@ export default {
           <tr class="table-secondary">
             <td></td>
             <td></td>
-            <td class="text-end"><strong>{{contestContents.nonWriteInTotal}}</strong></td>
+            <td class="text-end"><strong>{{contest.details.nonWriteInTotal}}</strong></td>
             <td class="text-end"><strong>100.00%</strong></td>
           </tr>
-          <tr v-if="contestContents.writeInTotal !== null">
+          <tr v-if="contest.details.writeInTotal !== null">
             <td></td>
             <td class="text-end">Write-Ins</td>
-            <td class="text-end">{{contestContents.writeInTotal}}</td>
+            <td class="text-end">{{contest.details.writeInTotal}}</td>
             <td class="text-end"></td>
           </tr>
         </tbody>

--- a/tests/unit/electionguard_gui/test_plaintext_ballot_service.py
+++ b/tests/unit/electionguard_gui/test_plaintext_ballot_service.py
@@ -28,7 +28,7 @@ class TestPlaintextBallotService(BaseTestCase):
         )
 
         # ASSERT
-        self.assertEqual(0, len(result.items()))
+        self.assertEqual(0, len(result))
 
     @patch("electionguard.tally.PlaintextTallySelection")
     def test_given_one_contest_with_valid_name_when_get_tally_report_then_name_returned(
@@ -52,8 +52,8 @@ class TestPlaintextBallotService(BaseTestCase):
         )
 
         # ASSERT
-        self.assertEqual(1, len(result.items()))
-        self.assertEqual("Contest 1", list(result.keys())[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual("Contest 1", result[0]["name"])
 
     @patch("electionguard.tally.PlaintextTallySelection")
     def test_given_one_contest_with_invalid_name_when_get_tally_report_then_name_is_na(
@@ -77,8 +77,8 @@ class TestPlaintextBallotService(BaseTestCase):
         )
 
         # ASSERT
-        self.assertEqual(1, len(result.items()))
-        self.assertEqual("n/a", list(result.keys())[0])
+        self.assertEqual(1, len(result))
+        self.assertEqual("n/a", list(result)[0]["name"])
 
     @patch("electionguard.tally.PlaintextTallySelection")
     @patch("electionguard.tally.PlaintextTallySelection")
@@ -112,9 +112,9 @@ class TestPlaintextBallotService(BaseTestCase):
         )
 
         # ASSERT
-        self.assertEqual(2, len(result.items()))
-        self.assertEqual("My Contest", list(result.keys())[0])
-        self.assertEqual("My Contest", list(result.keys())[1])
+        self.assertEqual(2, len(result))
+        self.assertEqual("My Contest", list(result)[0]["name"])
+        self.assertEqual("My Contest", list(result)[1]["name"])
 
     def test_zero_sections(self) -> None:
         # ARRANGE


### PR DESCRIPTION
### Issue

Fixes #764 

### Description
The report screen had a bug where it was removing contests that had identical names.  It no longer does this.

### Testing
Run an election with a manifest that contains duplicate contest names.  They will now show up again.