### PR TITLE
#768 - System now successfully resumes from sleep on guardian page

### DIFF
--- a/src/electionguard_gui/components/guardian_home_component.py
+++ b/src/electionguard_gui/components/guardian_home_component.py
@@ -49,10 +49,18 @@ class GuardianHomeComponent(ComponentBase):
         return eel_success(js_key_ceremonies)
 
     def watch_db_collections(self) -> None:
-        self._log.debug("Watching database")
-        db = self._db_service.get_db()
-        self._db_watcher_service.watch_database(db, None, notify_ui_db_changed)
-        self._log.debug("exited watching database")
+        try:
+            self._log.debug("Watching database")
+            db = self._db_service.get_db()
+            self._db_watcher_service.watch_database(db, None, notify_ui_db_changed)
+            self._log.debug("exited watching database")
+        except KeyboardInterrupt:
+            self._log.debug("Keyboard interrupt, exiting watch database")
+            self._db_watcher_service.stop_watching()
+        except Exception as e:  # pylint: disable=broad-except
+            self.handle_error(e)
+            self._db_watcher_service.stop_watching()
+            # no need to raise exception or return anything, we're in fire-and-forget mode here
 
     def stop_watching_db_collections(self) -> None:
         self._log.debug("Stopping watch database")

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -84,6 +84,7 @@ class KeyCeremonyDetailsComponent(ComponentBase):
             self._db_watcher_service.stop_watching()
         except Exception as e:  # pylint: disable=broad-except
             self.handle_error(e)
+            self._db_watcher_service.stop_watching()
             # we're in a fire-and-forget scenario, so no need to raise an exception or return anything
 
     def stop_watching_key_ceremony(self) -> None:

--- a/src/electionguard_gui/components/key_ceremony_details_component.py
+++ b/src/electionguard_gui/components/key_ceremony_details_component.py
@@ -70,14 +70,21 @@ class KeyCeremonyDetailsComponent(ComponentBase):
         eel.expose(self.stop_watching_key_ceremony)
 
     def watch_key_ceremony(self, key_ceremony_id: str) -> None:
-        db = self._db_service.get_db()
-        # retrieve and send the key ceremony to the client
-        self.on_key_ceremony_changed("key_ceremonies", key_ceremony_id)
-        self._log.debug(f"watching key ceremony '{key_ceremony_id}'")
-        # start watching for key ceremony changes from guardians
-        self._db_watcher_service.watch_database(
-            db, key_ceremony_id, self.on_key_ceremony_changed
-        )
+        try:
+            db = self._db_service.get_db()
+            # retrieve and send the key ceremony to the client
+            self.on_key_ceremony_changed("key_ceremonies", key_ceremony_id)
+            self._log.debug(f"watching key ceremony '{key_ceremony_id}'")
+            # start watching for key ceremony changes from guardians
+            self._db_watcher_service.watch_database(
+                db, key_ceremony_id, self.on_key_ceremony_changed
+            )
+        except KeyboardInterrupt:
+            self._log.debug("Keyboard interrupt, exiting watch database")
+            self._db_watcher_service.stop_watching()
+        except Exception as e:  # pylint: disable=broad-except
+            self.handle_error(e)
+            # we're in a fire-and-forget scenario, so no need to raise an exception or return anything
 
     def stop_watching_key_ceremony(self) -> None:
         self._db_watcher_service.stop_watching()

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -116,4 +116,4 @@ class MainApp:
             raise e
 
     def on_close(self, _page: str, _open_sockets: list) -> None:
-        self.log_service.info(f"To close the egui app hit Ctrl+C")
+        self.log_service.info("To close the egui app hit Ctrl+C")

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -101,8 +101,19 @@ class MainApp:
             port = self.config_service.get_port()
             host = self.config_service.get_host()
             self.log_service.debug(f"Starting eel port={port} mode={mode} host={host}")
-            eel.start("index.html", size=(1024, 768), port=port, mode=mode, host=host)
+            eel.start(
+                "index.html",
+                size=(1024, 768),
+                port=port,
+                mode=mode,
+                host=host,
+                close_callback=self.on_close,
+            )
+            self.log_service.info("Exiting main app normally")
         except Exception as e:
             self.log_service.error("error in main app start", e)
             traceback.print_exc()
             raise e
+
+    def on_close(self, _page: str, _open_sockets: list) -> None:
+        self.log_service.info(f"To close the egui app hit Ctrl+C")

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -116,4 +116,6 @@ class MainApp:
             raise e
 
     def on_close(self, _page: str, _open_sockets: list) -> None:
-        self.log_service.info("To close the egui app hit Ctrl+C")
+        self.log_service.info(
+            "To close the egui app ensure the browser tab is closed and hit Ctrl+C"
+        )

--- a/src/electionguard_gui/web/components/guardian/guardian-home-component.js
+++ b/src/electionguard_gui/web/components/guardian/guardian-home-component.js
@@ -2,6 +2,8 @@ import KeyCeremonyList from "../shared/key-ceremony-list-component.js";
 import DecryptionList from "./decryption-list-component.js";
 import Spinner from "../shared/spinner-component.js";
 
+const sleepResumeInterval = 2000;
+
 export default {
   components: {
     KeyCeremonyList,
@@ -13,6 +15,7 @@ export default {
       loading: true,
       decryptions: [],
       keyCeremonies: [],
+      lastAwakeTime: new Date().getTime(),
     };
   },
   methods: {
@@ -38,8 +41,18 @@ export default {
         console.error(result.error);
       }
     },
+    sleepResumeChecker: function () {
+      var currentTime = new Date().getTime();
+      if (currentTime > this.lastAwakeTime + sleepResumeInterval * 2) {
+        console.log("system appears to have returned from sleep, refreshing");
+        document.location.reload(true);
+      }
+      this.lastAwakeTime = currentTime;
+    },
   },
   async mounted() {
+    console.log("start sleepResumeChecker");
+    setInterval(this.sleepResumeChecker, sleepResumeInterval);
     eel.expose(this.keyCeremoniesChanged, "key_ceremonies_changed");
     eel.expose(this.decryptionsChanged, "decryptions_changed");
     console.log("begin watching for key ceremonies");
@@ -51,6 +64,7 @@ export default {
   unmounted() {
     console.log("stop watching key ceremonies");
     eel.stop_watching_db_collections();
+    clearInterval(this.sleepResumeChecker);
   },
   template: /*html*/ `
   <div class="container">

--- a/src/electionguard_gui/web/components/guardian/guardian-home-component.js
+++ b/src/electionguard_gui/web/components/guardian/guardian-home-component.js
@@ -21,11 +21,14 @@ export default {
   methods: {
     refresh: async function () {
       this.loading = true;
-      this.decryptions = [];
-      this.keyCeremonies = [];
-      await this.refreshDecryptions();
-      await this.refreshKeyCeremonies();
-      this.loading = false;
+      try {
+        this.decryptions = [];
+        this.keyCeremonies = [];
+        await this.refreshDecryptions();
+        await this.refreshKeyCeremonies();
+      } finally {
+        this.loading = false;
+      }
     },
     keyCeremoniesChanged: async function () {
       await this.refreshKeyCeremonies();
@@ -59,7 +62,6 @@ export default {
     },
   },
   async mounted() {
-    console.log("start sleepResumeChecker");
     setInterval(this.sleepResumeChecker, sleepResumeInterval);
     eel.expose(this.keyCeremoniesChanged, "key_ceremonies_changed");
     eel.expose(this.decryptionsChanged, "decryptions_changed");

--- a/src/electionguard_gui/web/components/guardian/guardian-home-component.js
+++ b/src/electionguard_gui/web/components/guardian/guardian-home-component.js
@@ -19,6 +19,14 @@ export default {
     };
   },
   methods: {
+    refresh: async function () {
+      this.loading = true;
+      this.decryptions = [];
+      this.keyCeremonies = [];
+      await this.refreshDecryptions();
+      await this.refreshKeyCeremonies();
+      this.loading = false;
+    },
     keyCeremoniesChanged: async function () {
       await this.refreshKeyCeremonies();
     },
@@ -68,7 +76,14 @@ export default {
   },
   template: /*html*/ `
   <div class="container">
-    <h1>Guardian Home</h1>
+    <div class="row">
+      <div class="col-11">
+        <h1>Guardian Home</h1>
+      </div>
+      <div class="col-1 text-end">
+        <button class="btn btn-lg btn-light" @click="refresh"><i class="bi-arrow-clockwise"></i></button>
+      </div>
+    </div>
     <spinner :visible="loading"></spinner>
     <div v-if="!loading" class="row">
       <div class="col-12 col-lg-6">


### PR DESCRIPTION
### Issue

Fixes #768 

### Description
The underlying issue was that Eel in Python would die when the system was resuming from sleep.  The web-based UI then looked like it was still working when in fact the server had crashed.  That gave the appearance of key ceremonies and decryptions not appearing on guardian devices when they should have, when in fact the issue was much larger.

The server-side solution is to disallow eel from ever exiting of its own accord.  This allows eel to resume from system sleep, although it has the consequence that the user must now explicitly hit Ctrl+C to end the app.

The client-side solution is to watch for system resume events and when they occur refresh the page.  This solution also adds a refresh button for convenience, although the prior solutions should warrant it unnecessary.

### Testing
1. Run the app as a guardian
2. Sleep/hibernate your system
3. Have an admin add a key ceremony

Expected the guardian should see the new key ceremony on their home page