### PR TITLE
#762 Version Info

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -373,28 +373,6 @@ python-dateutil = ">=2.8.1"
 dev = ["twine", "markdown", "flake8", "wheel"]
 
 [[package]]
-name = "gitdb"
-version = "4.0.9"
-description = "Git Object Database"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-smmap = ">=3.0.1,<6"
-
-[[package]]
-name = "gitpython"
-version = "3.1.27"
-description = "GitPython is a python library used to interact with Git repositories"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-gitdb = ">=4.0.1,<5"
-
-[[package]]
 name = "gmpy2"
 version = "2.1.2"
 description = "gmpy2 interface to GMP/MPIR, MPFR, and MPC for Python 2.7 and 3.5+"
@@ -1580,14 +1558,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "smmap"
-version = "5.0.0"
-description = "A pure Python implementation of a sliding window memory map manager"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1850,7 +1820,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9.5"
-content-hash = "3005264fd26dd2154ca4c20f141370dc0bc223cad1e8e88422b5fa56cceb43e5"
+content-hash = "b24de109f5a822b6c0a07839048d7ddaffbc18edad0a34a6ef01d6d49edb319f"
 
 [metadata.files]
 appnope = [
@@ -2145,8 +2115,6 @@ ghp-import = [
     {file = "ghp-import-2.0.2.tar.gz", hash = "sha256:947b3771f11be850c852c64b561c600fdddf794bab363060854c1ee7ad05e071"},
     {file = "ghp_import-2.0.2-py3-none-any.whl", hash = "sha256:5f8962b30b20652cdffa9c5a9812f7de6bcb56ec475acac579807719bf242c46"},
 ]
-gitdb = []
-gitpython = []
 gmpy2 = [
     {file = "gmpy2-2.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:fdeb0ebc314a326137908c8d51c4b0091aae84ceb4c35836d7d29bcfedf70856"},
     {file = "gmpy2-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d9b0f948bc99c6490b2716f4e7197006dd9984c85447365b0c0b08be65f8e27d"},
@@ -2924,7 +2892,6 @@ six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
-smmap = []
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,7 +177,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
@@ -218,7 +218,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dev = ["pylint", "mypy", "black", "coveralls", "pytest-cov", "pytest (>=5)"]
+dev = ["pytest (>=5)", "pytest-cov", "coveralls", "black", "mypy", "pylint"]
 
 [[package]]
 name = "debugpy"
@@ -370,7 +370,29 @@ python-versions = "*"
 python-dateutil = ">=2.8.1"
 
 [package.extras]
-dev = ["wheel", "flake8", "markdown", "twine"]
+dev = ["twine", "markdown", "flake8", "wheel"]
+
+[[package]]
+name = "gitdb"
+version = "4.0.9"
+description = "Git Object Database"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.27"
+description = "GitPython is a python library used to interact with Git repositories"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "gmpy2"
@@ -587,8 +609,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-mypy", "pytest-black (>=0.3.7)", "pytest-enabler", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=1.2.3)", "pytest (>=3.5,!=3.7.3)"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "jaraco.text"
@@ -619,8 +641,8 @@ python-versions = ">=3.6"
 "jaraco.text" = "*"
 
 [package.extras]
-testing = ["pytest-mypy", "pytest-black (>=0.3.7)", "pytest-enabler", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=1.2.3)", "pytest (>=3.5,!=3.7.3)"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=8.2)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "jaraco.windows"
@@ -666,8 +688,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-trio = ["async-generator", "trio"]
-test = ["async-timeout", "trio", "testpath", "pytest-asyncio (>=0.17)", "pytest-trio", "pytest"]
+test = ["pytest", "pytest-trio", "pytest-asyncio (>=0.17)", "testpath", "trio", "async-timeout"]
+trio = ["trio", "async-generator"]
 
 [[package]]
 name = "jinja2"
@@ -713,8 +735,8 @@ ipython = ">=7.27.0,<8"
 tokenize-rt = ">=4.1.0,<5"
 
 [package.extras]
-test = ["tox (>=3.24.3,<4)", "pytest (>=6.2.5,<7)", "pylint (>=2.10.2,<2.11)", "playwright (>=1.14.1,<2)", "pep8-naming (>=0.12.1,<0.13)", "mypy (>=0.910,<1)", "jupyterlab (==3.3.0)", "flake8-import-order (>=0.18.1,<0.19)", "flake8-docstrings (>=1.6.0,<2)", "flake8 (>=3.9.2,<4)"]
-dev = ["wheel (>=0.37.0,<0.38)", "twine (>=3.4.2,<4)", "build (>=0.6.0.post1,<0.7)"]
+dev = ["build (>=0.6.0.post1,<0.7)", "twine (>=3.4.2,<4)", "wheel (>=0.37.0,<0.38)"]
+test = ["flake8 (>=3.9.2,<4)", "flake8-docstrings (>=1.6.0,<2)", "flake8-import-order (>=0.18.1,<0.19)", "jupyterlab (==3.3.0)", "mypy (>=0.910,<1)", "pep8-naming (>=0.12.1,<0.13)", "playwright (>=1.14.1,<2)", "pylint (>=2.10.2,<2.11)", "pytest (>=6.2.5,<7)", "tox (>=3.24.3,<4)"]
 
 [[package]]
 name = "jupyter-client"
@@ -846,13 +868,13 @@ attrs = ">=19,<22"
 mdurl = ">=0.1,<1.0"
 
 [package.extras]
-testing = ["pytest-regressions", "pytest-cov", "pytest", "coverage"]
-rtd = ["sphinx-book-theme", "sphinx-panels (>=0.4.0,<0.5.0)", "sphinx-copybutton", "sphinx (>=2,<4)", "pyyaml", "myst-nb (==0.13.0a1)"]
-plugins = ["mdit-py-plugins"]
-linkify = ["linkify-it-py (>=1.0,<2.0)"]
-compare = ["panflute (>=1.12,<2.0)", "mistune (>=0.8.4,<0.9.0)", "mistletoe-ebp (>=0.10.0,<0.11.0)", "markdown (>=3.2.2,<3.3.0)", "commonmark (>=0.9.1,<0.10.0)"]
+benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
 code_style = ["pre-commit (==2.6)"]
-benchmarking = ["pytest-benchmark (>=3.2,<4.0)", "pytest", "psutil"]
+compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.2.2,<3.3.0)", "mistletoe-ebp (>=0.10.0,<0.11.0)", "mistune (>=0.8.4,<0.9.0)", "panflute (>=1.12,<2.0)"]
+linkify = ["linkify-it-py (>=1.0,<2.0)"]
+plugins = ["mdit-py-plugins"]
+rtd = ["myst-nb (==0.13.0a1)", "pyyaml", "sphinx (>=2,<4)", "sphinx-copybutton", "sphinx-panels (>=0.4.0,<0.5.0)", "sphinx-book-theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "markupsafe"
@@ -893,9 +915,9 @@ python-versions = "~=3.6"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-testing = ["pytest-regressions", "pytest-cov", "pytest (>=3.6,<4)", "coverage"]
-rtd = ["sphinx-book-theme (>=0.1.0,<0.2.0)", "myst-parser (>=0.14.0,<0.15.0)"]
 code_style = ["pre-commit (==2.6)"]
+rtd = ["myst-parser (>=0.14.0,<0.15.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
+testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "mdurl"
@@ -1222,8 +1244,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prompt-toolkit"
@@ -1558,6 +1580,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "smmap"
+version = "5.0.0"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1820,7 +1850,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9.5"
-content-hash = "b24de109f5a822b6c0a07839048d7ddaffbc18edad0a34a6ef01d6d49edb319f"
+content-hash = "3005264fd26dd2154ca4c20f141370dc0bc223cad1e8e88422b5fa56cceb43e5"
 
 [metadata.files]
 appnope = [
@@ -1876,10 +1906,7 @@ bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
-bottle = [
-    {file = "bottle-0.12.20-py3-none-any.whl", hash = "sha256:3c97e1e955c11e4ad2d73a60cdf83c4f4cf7b8b73c8344fc4b72f985432605cb"},
-    {file = "bottle-0.12.20.tar.gz", hash = "sha256:544023cd2cd6d382ebf9675fa0544d4d20e19d3a13b6932a812d099fb2f6cb84"},
-]
+bottle = []
 bottle-websocket = [
     {file = "bottle-websocket-0.2.9.tar.gz", hash = "sha256:9887f70dc0c7592ed8d0d11a14aa95dede6cd08d50d83d5b81fd963e5fec738b"},
 ]
@@ -2052,44 +2079,7 @@ defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-dependency-injector = [
-    {file = "dependency-injector-4.39.1.tar.gz", hash = "sha256:9ab76dc5e19b2692aaca49e00f9b41a087138d139b0ec985f92ff0498f038772"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c788a3d5482e63b5fd55e14fc258f1ff0b51b411927ab132ef0f689cb5d1183f"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0832e0457a360725cd1d1037b77b85478aeeaacc60e85ecceeb8020409e7b62"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d51998fff9704fd01d11c3c48f4e88d8506cb6afa1ee41409a881a5a51dae3fc"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea484cd13fc62966bf5582df0816205feee072d18f228aac75f7807b43f223ae"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-win32.whl", hash = "sha256:17389e53ec29ca13570319cf2065dcc4c2f6d36db5dd792bb1e8f2c39a9f146b"},
-    {file = "dependency_injector-4.39.1-cp310-cp310-win_amd64.whl", hash = "sha256:55b0988489267c5a580f419133770ffe293057f2064da1c9ad6a2cc69666739b"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b297c3e79d3633cc56366386ae1f7dbce1587673cca2f559c368c1e936a1fa94"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2728827c5abb2420c5811e218262ae1b77a48e76cc9eebc6b4f55fee48a1a18d"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:029e42b064ab8cb5b2559be040ff682c7aa81592f1654a82355475956df17803"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:305e3db3f4bf40f64caaa1303e03005174e78d2339d2ae517b34c011ec2300f9"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-win32.whl", hash = "sha256:a661dd23a5e4e2f6bf4a729de7fadbe148c9a4a298dbcadfc5a94584b6930970"},
-    {file = "dependency_injector-4.39.1-cp36-cp36m-win_amd64.whl", hash = "sha256:340d6e7af5c4729d20c837d6d1e8a2626c24a05259dff746406cc823e26ba1e7"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a1553dac1c95f0de1f910b0025ee4570ea078a07d576bcdc2168990e719cea50"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c7baaa64d93359ee08c15d68579cc803e11d9becaf961f5a66b94ff627248e1"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7a27bf1951a066cf347b886cc7ab0f37dcbd1ad59bffcfe721c8c12a189a150d"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da6e2d685f7d0c65257f08133b68d9bf74ec319b90a0f21b4f629d168ce5f68f"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-win32.whl", hash = "sha256:a8ddd03ca86e67e9d3cc038793d34fbfccab12e6145df813e72bf14f9371f2ea"},
-    {file = "dependency_injector-4.39.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e01a319ea05cd86b520201386dcb53a81a5400cb82fcc2f006bd7e92c0c51a0a"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4704804bde25b694aa65201927937a9d82d8bc055cb3dadc68eb05988bd34fa9"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0935d50b263169e7b0826a2fb6be80d6a4f2a7c59e6dd9876f86da3243bea9eb"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3c34aa5abb1826b6189f47daf6e469d4293c1d01693233da2c1b923816270cc5"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:db64904c9b9a88756cfece3e3ed078a2b57127642711dd08af342dba8abf9667"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-win32.whl", hash = "sha256:66ebe728194adc8720dbc4d662edbbfa55659ff23c9c493fb2dae0bfd4df5734"},
-    {file = "dependency_injector-4.39.1-cp38-cp38-win_amd64.whl", hash = "sha256:4349974620f630d6726808e1291ec99713b64d449b84eb01581ee807a5a5c224"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d87cad0899b05cd08931bfb68ddf7be77711a67b0649c37f2045d7808977b082"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8efd965e5cfdd9f339ec895e73c119569851adedc175088d34a670f5206fea63"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:27f69485ca6b85c31d162ee86cf6ef71bb71dce9cd2b5d0745425dfc551eefa1"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a25b63de59dff04ec78f5161f00c0222a04a23def5d1f0eda14e389a32baf428"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-win32.whl", hash = "sha256:a14274f50d125b4579314c355e22af07def1a96641ca94bd75edcf1400b89477"},
-    {file = "dependency_injector-4.39.1-cp39-cp39-win_amd64.whl", hash = "sha256:9950039d00625f9252cd26378a4406342b256886bb61e4db8b65e9f01270f53e"},
-    {file = "dependency_injector-4.39.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6d7f39cd54678741e132e13da3a1367ac18058cbda61fe39d61c8583aa6fd757"},
-    {file = "dependency_injector-4.39.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2368c7ba3c9ffaf816ea0f2d14c78d481491b805f62ac8496a78a51397d4689"},
-    {file = "dependency_injector-4.39.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:84e32407bb16c58aa0d4b5ed8485537bc66ccc14cfffae7022f1204e35ec939a"},
-    {file = "dependency_injector-4.39.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f2d80a42c546e1f934d427b071630d86653cd4a60c74b570c4ffb03025c1f1f9"},
-    {file = "dependency_injector-4.39.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ca126bbed370b8c002c859ebeb76f6d83eba2d7fb5d66f37f47cfc19661d2889"},
-]
+dependency-injector = []
 dill = [
     {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
     {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
@@ -2155,6 +2145,8 @@ ghp-import = [
     {file = "ghp-import-2.0.2.tar.gz", hash = "sha256:947b3771f11be850c852c64b561c600fdddf794bab363060854c1ee7ad05e071"},
     {file = "ghp_import-2.0.2-py3-none-any.whl", hash = "sha256:5f8962b30b20652cdffa9c5a9812f7de6bcb56ec475acac579807719bf242c46"},
 ]
+gitdb = []
+gitpython = []
 gmpy2 = [
     {file = "gmpy2-2.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:fdeb0ebc314a326137908c8d51c4b0091aae84ceb4c35836d7d29bcfedf70856"},
     {file = "gmpy2-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d9b0f948bc99c6490b2716f4e7197006dd9984c85447365b0c0b08be65f8e27d"},
@@ -2389,78 +2381,7 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
-lxml = [
-    {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
-    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c62e8dd9754b7debda0c5ba59d34509c4688f853588d75b53c3791983faa96fc"},
-    {file = "lxml-4.9.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21fb3d24ab430fc538a96e9fbb9b150029914805d551deeac7d7822f64631dfc"},
-    {file = "lxml-4.9.1-cp27-cp27m-win32.whl", hash = "sha256:86e92728ef3fc842c50a5cb1d5ba2bc66db7da08a7af53fb3da79e202d1b2cd3"},
-    {file = "lxml-4.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4cfbe42c686f33944e12f45a27d25a492cc0e43e1dc1da5d6a87cbcaf2e95627"},
-    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dad7b164905d3e534883281c050180afcf1e230c3d4a54e8038aa5cfcf312b84"},
-    {file = "lxml-4.9.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a614e4afed58c14254e67862456d212c4dcceebab2eaa44d627c2ca04bf86837"},
-    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:f9ced82717c7ec65a67667bb05865ffe38af0e835cdd78728f1209c8fffe0cad"},
-    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d9fc0bf3ff86c17348dfc5d322f627d78273eba545db865c3cd14b3f19e57fa5"},
-    {file = "lxml-4.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:e5f66bdf0976ec667fc4594d2812a00b07ed14d1b44259d19a41ae3fff99f2b8"},
-    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:fe17d10b97fdf58155f858606bddb4e037b805a60ae023c009f760d8361a4eb8"},
-    {file = "lxml-4.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8caf4d16b31961e964c62194ea3e26a0e9561cdf72eecb1781458b67ec83423d"},
-    {file = "lxml-4.9.1-cp310-cp310-win32.whl", hash = "sha256:4780677767dd52b99f0af1f123bc2c22873d30b474aa0e2fc3fe5e02217687c7"},
-    {file = "lxml-4.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:b122a188cd292c4d2fcd78d04f863b789ef43aa129b233d7c9004de08693728b"},
-    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:be9eb06489bc975c38706902cbc6888f39e946b81383abc2838d186f0e8b6a9d"},
-    {file = "lxml-4.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f1be258c4d3dc609e654a1dc59d37b17d7fef05df912c01fc2e15eb43a9735f3"},
-    {file = "lxml-4.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:927a9dd016d6033bc12e0bf5dee1dde140235fc8d0d51099353c76081c03dc29"},
-    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9232b09f5efee6a495a99ae6824881940d6447debe272ea400c02e3b68aad85d"},
-    {file = "lxml-4.9.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:04da965dfebb5dac2619cb90fcf93efdb35b3c6994fea58a157a834f2f94b318"},
-    {file = "lxml-4.9.1-cp35-cp35m-win32.whl", hash = "sha256:4d5bae0a37af799207140652a700f21a85946f107a199bcb06720b13a4f1f0b7"},
-    {file = "lxml-4.9.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4878e667ebabe9b65e785ac8da4d48886fe81193a84bbe49f12acff8f7a383a4"},
-    {file = "lxml-4.9.1-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:1355755b62c28950f9ce123c7a41460ed9743c699905cbe664a5bcc5c9c7c7fb"},
-    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:bcaa1c495ce623966d9fc8a187da80082334236a2a1c7e141763ffaf7a405067"},
-    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eafc048ea3f1b3c136c71a86db393be36b5b3d9c87b1c25204e7d397cee9536"},
-    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:13c90064b224e10c14dcdf8086688d3f0e612db53766e7478d7754703295c7c8"},
-    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206a51077773c6c5d2ce1991327cda719063a47adc02bd703c56a662cdb6c58b"},
-    {file = "lxml-4.9.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e8f0c9d65da595cfe91713bc1222af9ecabd37971762cb830dea2fc3b3bb2acf"},
-    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8f0a4d179c9a941eb80c3a63cdb495e539e064f8054230844dcf2fcb812b71d3"},
-    {file = "lxml-4.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:830c88747dce8a3e7525defa68afd742b4580df6aa2fdd6f0855481e3994d391"},
-    {file = "lxml-4.9.1-cp36-cp36m-win32.whl", hash = "sha256:1e1cf47774373777936c5aabad489fef7b1c087dcd1f426b621fda9dcc12994e"},
-    {file = "lxml-4.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:5974895115737a74a00b321e339b9c3f45c20275d226398ae79ac008d908bff7"},
-    {file = "lxml-4.9.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:1423631e3d51008871299525b541413c9b6c6423593e89f9c4cfbe8460afc0a2"},
-    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:2aaf6a0a6465d39b5ca69688fce82d20088c1838534982996ec46633dc7ad6cc"},
-    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:9f36de4cd0c262dd9927886cc2305aa3f2210db437aa4fed3fb4940b8bf4592c"},
-    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ae06c1e4bc60ee076292e582a7512f304abdf6c70db59b56745cca1684f875a4"},
-    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:57e4d637258703d14171b54203fd6822fda218c6c2658a7d30816b10995f29f3"},
-    {file = "lxml-4.9.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d279033bf614953c3fc4a0aa9ac33a21e8044ca72d4fa8b9273fe75359d5cca"},
-    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:a60f90bba4c37962cbf210f0188ecca87daafdf60271f4c6948606e4dabf8785"},
-    {file = "lxml-4.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:6ca2264f341dd81e41f3fffecec6e446aa2121e0b8d026fb5130e02de1402785"},
-    {file = "lxml-4.9.1-cp37-cp37m-win32.whl", hash = "sha256:27e590352c76156f50f538dbcebd1925317a0f70540f7dc8c97d2931c595783a"},
-    {file = "lxml-4.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:eea5d6443b093e1545ad0210e6cf27f920482bfcf5c77cdc8596aec73523bb7e"},
-    {file = "lxml-4.9.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f05251bbc2145349b8d0b77c0d4e5f3b228418807b1ee27cefb11f69ed3d233b"},
-    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:487c8e61d7acc50b8be82bda8c8d21d20e133c3cbf41bd8ad7eb1aaeb3f07c97"},
-    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8d1a92d8e90b286d491e5626af53afef2ba04da33e82e30744795c71880eaa21"},
-    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:b570da8cd0012f4af9fa76a5635cd31f707473e65a5a335b186069d5c7121ff2"},
-    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ef87fca280fb15342726bd5f980f6faf8b84a5287fcc2d4962ea8af88b35130"},
-    {file = "lxml-4.9.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:93e414e3206779ef41e5ff2448067213febf260ba747fc65389a3ddaa3fb8715"},
-    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6653071f4f9bac46fbc30f3c7838b0e9063ee335908c5d61fb7a4a86c8fd2036"},
-    {file = "lxml-4.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:32a73c53783becdb7eaf75a2a1525ea8e49379fb7248c3eeefb9412123536387"},
-    {file = "lxml-4.9.1-cp38-cp38-win32.whl", hash = "sha256:1a7c59c6ffd6ef5db362b798f350e24ab2cfa5700d53ac6681918f314a4d3b94"},
-    {file = "lxml-4.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:1436cf0063bba7888e43f1ba8d58824f085410ea2025befe81150aceb123e345"},
-    {file = "lxml-4.9.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4beea0f31491bc086991b97517b9683e5cfb369205dac0148ef685ac12a20a67"},
-    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41fb58868b816c202e8881fd0f179a4644ce6e7cbbb248ef0283a34b73ec73bb"},
-    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:bd34f6d1810d9354dc7e35158aa6cc33456be7706df4420819af6ed966e85448"},
-    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:edffbe3c510d8f4bf8640e02ca019e48a9b72357318383ca60e3330c23aaffc7"},
-    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6d949f53ad4fc7cf02c44d6678e7ff05ec5f5552b235b9e136bd52e9bf730b91"},
-    {file = "lxml-4.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:079b68f197c796e42aa80b1f739f058dcee796dc725cc9a1be0cdb08fc45b000"},
-    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c3a88d20e4fe4a2a4a84bf439a5ac9c9aba400b85244c63a1ab7088f85d9d25"},
-    {file = "lxml-4.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4e285b5f2bf321fc0857b491b5028c5f276ec0c873b985d58d7748ece1d770dd"},
-    {file = "lxml-4.9.1-cp39-cp39-win32.whl", hash = "sha256:ef72013e20dd5ba86a8ae1aed7f56f31d3374189aa8b433e7b12ad182c0d2dfb"},
-    {file = "lxml-4.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:10d2017f9150248563bb579cd0d07c61c58da85c922b780060dcc9a3aa9f432d"},
-    {file = "lxml-4.9.1-pp37-pypy37_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538747a9d7827ce3e16a8fdd201a99e661c7dee3c96c885d8ecba3c35d1032c"},
-    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0645e934e940107e2fdbe7c5b6fb8ec6232444260752598bc4d09511bd056c0b"},
-    {file = "lxml-4.9.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6daa662aba22ef3258934105be2dd9afa5bb45748f4f702a3b39a5bf53a1f4dc"},
-    {file = "lxml-4.9.1-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:603a464c2e67d8a546ddaa206d98e3246e5db05594b97db844c2f0a1af37cf5b"},
-    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c4b2e0559b68455c085fb0f6178e9752c4be3bba104d6e881eb5573b399d1eb2"},
-    {file = "lxml-4.9.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0f3f0059891d3254c7b5fb935330d6db38d6519ecd238ca4fce93c234b4a0f73"},
-    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c852b1530083a620cb0de5f3cd6826f19862bafeaf77586f1aef326e49d95f0c"},
-    {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:287605bede6bd36e930577c5925fcea17cb30453d96a7b4c63c14a257118dbb9"},
-    {file = "lxml-4.9.1.tar.gz", hash = "sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"},
-]
+lxml = []
 markdown = [
     {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
     {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
@@ -2592,10 +2513,7 @@ nbclient = [
     {file = "nbclient-0.5.13-py3-none-any.whl", hash = "sha256:47ac905af59379913c1f8f541098d2550153cf8dc58553cbe18c702b181518b0"},
     {file = "nbclient-0.5.13.tar.gz", hash = "sha256:40c52c9b5e3c31faecaee69f202b3f53e38d7c1c563de0fadde9d7eda0fdafe8"},
 ]
-nbconvert = [
-    {file = "nbconvert-6.5.1-py3-none-any.whl", hash = "sha256:0a3e224ee753ac4dceeb0257c4a315c069dcc6f9f4ae0ad15c5ea84713d15e28"},
-    {file = "nbconvert-6.5.1.tar.gz", hash = "sha256:2c01f3f518fee736c3d3f999dd20e0a16febba17a0d60a3b0fd28fbdec14115d"},
-]
+nbconvert = []
 nbformat = [
     {file = "nbformat-5.3.0-py3-none-any.whl", hash = "sha256:38856d97de49e8292e2d5d8f595e9d26f02abfd87e075d450af4511870b40538"},
     {file = "nbformat-5.3.0.tar.gz", hash = "sha256:fcc5ab8cb74e20b19570b5be809e2dba9b82836fd2761a89066ad43394ba29f5"},
@@ -2867,10 +2785,7 @@ pytest = [
     {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
     {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
 ]
-pytest-mock = [
-    {file = "pytest-mock-3.8.2.tar.gz", hash = "sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2"},
-    {file = "pytest_mock-3.8.2-py3-none-any.whl", hash = "sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948"},
-]
+pytest-mock = []
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
@@ -3009,6 +2924,7 @@ six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+smmap = []
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
@@ -3021,10 +2937,7 @@ stdlib-list = [
     {file = "stdlib-list-0.8.0.tar.gz", hash = "sha256:a1e503719720d71e2ed70ed809b385c60cd3fb555ba7ec046b96360d30b16d9f"},
     {file = "stdlib_list-0.8.0-py3-none-any.whl", hash = "sha256:2ae0712a55b68f3fbbc9e58d6fa1b646a062188f49745b495f94d3310a9fdd3e"},
 ]
-tinycss2 = [
-    {file = "tinycss2-1.1.1-py3-none-any.whl", hash = "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"},
-    {file = "tinycss2-1.1.1.tar.gz", hash = "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf"},
-]
+tinycss2 = []
 tokenize-rt = [
     {file = "tokenize_rt-4.2.1-py2.py3-none-any.whl", hash = "sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8"},
     {file = "tokenize_rt-4.2.1.tar.gz", hash = "sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ Eel = {extras = ["jinja2"], version = "^0.14.0"}
 pymongo = "^4.1.1"
 dependency-injector = "^4.39.1"
 pytest-mock = "^3.8.2"
+GitPython = "^3.1.27"
 
 [tool.poetry.dev-dependencies]
 atomicwrites = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ Eel = {extras = ["jinja2"], version = "^0.14.0"}
 pymongo = "^4.1.1"
 dependency-injector = "^4.39.1"
 pytest-mock = "^3.8.2"
-GitPython = "^3.1.27"
 
 [tool.poetry.dev-dependencies]
 atomicwrites = "*"

--- a/src/electionguard_gui/__init__.py
+++ b/src/electionguard_gui/__init__.py
@@ -93,6 +93,7 @@ from electionguard_gui.services import (
     MODE_KEY,
     PORT_KEY,
     ServiceBase,
+    VersionService,
     announce_guardians,
     authorization_service,
     backup_to_dict,
@@ -139,6 +140,7 @@ from electionguard_gui.services import (
     status_descriptions,
     to_ballot_share_raw,
     verification_to_dict,
+    version_service,
 )
 from electionguard_gui.start import (
     run,
@@ -192,6 +194,7 @@ __all__ = [
     "PORT_KEY",
     "ServiceBase",
     "UploadBallotsComponent",
+    "VersionService",
     "ViewDecryptionComponent",
     "ViewElectionComponent",
     "ViewSpoiledBallotComponent",
@@ -271,6 +274,7 @@ __all__ = [
     "upload_ballots_component",
     "utc_to_str",
     "verification_to_dict",
+    "version_service",
     "view_decryption_component",
     "view_election_component",
     "view_spoiled_ballot_component",

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -35,6 +35,7 @@ from electionguard_gui.services import (
     DecryptionService,
     DbWatcherService,
     ConfigurationService,
+    VersionService,
 )
 from electionguard_gui.services.decryption_stages import (
     DecryptionS1JoinService,
@@ -126,6 +127,7 @@ class Container(containers.DeclarativeContainer):
     )
 
     # key ceremony services
+    version_service: Factory[VersionService] = providers.Factory(VersionService)
     key_ceremony_s1_join_service: Factory[KeyCeremonyS1JoinService] = providers.Factory(
         KeyCeremonyS1JoinService,
         log_service=log_service,
@@ -302,4 +304,5 @@ class Container(containers.DeclarativeContainer):
         export_election_record_component=export_election_record_component,
         view_tally_component=view_tally_component,
         view_spoiled_ballot_component=view_spoiled_ballot_component,
+        version_service=version_service,
     )

--- a/src/electionguard_gui/containers.py
+++ b/src/electionguard_gui/containers.py
@@ -59,6 +59,9 @@ class Container(containers.DeclarativeContainer):
     config_service: Factory[ConfigurationService] = providers.Factory(
         ConfigurationService
     )
+    version_service: Factory[VersionService] = providers.Factory(
+        VersionService, log_service=log_service
+    )
     db_service: Singleton[DbService] = providers.Singleton(
         DbService, log_service=log_service, config_service=config_service
     )
@@ -127,7 +130,6 @@ class Container(containers.DeclarativeContainer):
     )
 
     # key ceremony services
-    version_service: Factory[VersionService] = providers.Factory(VersionService)
     key_ceremony_s1_join_service: Factory[KeyCeremonyS1JoinService] = providers.Factory(
         KeyCeremonyS1JoinService,
         log_service=log_service,

--- a/src/electionguard_gui/main_app.py
+++ b/src/electionguard_gui/main_app.py
@@ -25,6 +25,7 @@ from electionguard_gui.services import (
     EelLogService,
     ServiceBase,
     ConfigurationService,
+    VersionService,
 )
 
 
@@ -55,6 +56,7 @@ class MainApp:
         export_election_record_component: ExportElectionRecordComponent,
         view_tally_component: ViewTallyComponent,
         view_spoiled_ballot_component: ViewSpoiledBallotComponent,
+        version_service: VersionService,
     ) -> None:
         super().__init__()
 
@@ -83,6 +85,7 @@ class MainApp:
             authorization_service,
             db_service,
             log_service,
+            version_service,
         ]
 
     def start(self) -> None:

--- a/src/electionguard_gui/services/__init__.py
+++ b/src/electionguard_gui/services/__init__.py
@@ -17,6 +17,7 @@ from electionguard_gui.services import key_ceremony_stages
 from electionguard_gui.services import key_ceremony_state_service
 from electionguard_gui.services import plaintext_ballot_service
 from electionguard_gui.services import service_base
+from electionguard_gui.services import version_service
 
 from electionguard_gui.services.authorization_service import (
     AuthorizationService,
@@ -113,6 +114,9 @@ from electionguard_gui.services.plaintext_ballot_service import (
 from electionguard_gui.services.service_base import (
     ServiceBase,
 )
+from electionguard_gui.services.version_service import (
+    VersionService,
+)
 
 __all__ = [
     "AuthorizationService",
@@ -145,6 +149,7 @@ __all__ = [
     "MODE_KEY",
     "PORT_KEY",
     "ServiceBase",
+    "VersionService",
     "announce_guardians",
     "authorization_service",
     "backup_to_dict",
@@ -191,4 +196,5 @@ __all__ = [
     "status_descriptions",
     "to_ballot_share_raw",
     "verification_to_dict",
+    "version_service",
 ]

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,4 +1,5 @@
 from os import path
+from typing import Optional
 import eel
 from git import Repo
 from electionguard_gui.services.eel_log_service import EelLogService
@@ -16,12 +17,11 @@ class VersionService(ServiceBase):
     def expose(self) -> None:
         eel.expose(self.get_version)
 
-    def get_version(self) -> str:
-        if path.exists(".git"):
-            repo = Repo("./")
-            commit_hash = repo.git.rev_parse("HEAD")
-            short_hash = commit_hash[:6]
-            self._log.info(f"Version: {short_hash}")
-            return short_hash
-        else:
-            return "unknown"
+    def get_version(self) -> Optional[str]:
+        if not path.exists(".git"):
+            return None
+        repo = Repo("./")
+        commit_hash = repo.git.rev_parse("HEAD")
+        short_hash = commit_hash[:6]
+        self._log.info(f"Version: {short_hash}")
+        return short_hash

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,7 +1,7 @@
 from os import path
+from subprocess import Popen, PIPE, check_output
 from typing import Optional
 import eel
-from git import Repo
 from electionguard_gui.services.eel_log_service import EelLogService
 from electionguard_gui.services.service_base import ServiceBase
 
@@ -20,8 +20,9 @@ class VersionService(ServiceBase):
     def get_version(self) -> Optional[str]:
         if not path.exists(".git"):
             return None
-        repo = Repo("./")
-        commit_hash = repo.git.rev_parse("HEAD")
-        short_hash = str(commit_hash[:6])
-        self._log.info(f"Version: {short_hash}")
-        return short_hash
+        commit_hash = (
+            check_output(["git", "rev-parse", "--short", "HEAD"])
+            .decode("ascii")
+            .strip()
+        )
+        return commit_hash

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,5 +1,5 @@
 from os import path
-from subprocess import Popen, PIPE, check_output
+from subprocess import check_output
 from typing import Optional
 import eel
 from electionguard_gui.services.eel_log_service import EelLogService
@@ -25,4 +25,5 @@ class VersionService(ServiceBase):
             .decode("ascii")
             .strip()
         )
+        self._log.info(f"Version: {commit_hash}")
         return commit_hash

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -11,7 +11,7 @@ class VersionService(ServiceBase):
 
     _log: EelLogService
 
-    def __init__(self, log_service: ServiceBase) -> None:
+    def __init__(self, log_service: EelLogService) -> None:
         self._log = log_service
 
     def expose(self) -> None:
@@ -22,6 +22,6 @@ class VersionService(ServiceBase):
             return None
         repo = Repo("./")
         commit_hash = repo.git.rev_parse("HEAD")
-        short_hash = commit_hash[:6]
+        short_hash = str(commit_hash[:6])
         self._log.info(f"Version: {short_hash}")
         return short_hash

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,12 +1,23 @@
 import eel
+from git import Repo
+from electionguard_gui.services.eel_log_service import EelLogService
 from electionguard_gui.services.service_base import ServiceBase
 
 
 class VersionService(ServiceBase):
     """Responsible for retrieving version information"""
 
+    _log: EelLogService
+
+    def __init__(self, log_service: ServiceBase) -> None:
+        self._log = log_service
+
     def expose(self) -> None:
         eel.expose(self.get_version)
 
     def get_version(self) -> str:
-        return "0.0.1"
+        repo = Repo("./")
+        commit_hash = repo.git.rev_parse("HEAD")
+        short_hash = commit_hash[:6]
+        self._log.info(f"Version: {short_hash}")
+        return short_hash

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,0 +1,12 @@
+import eel
+from electionguard_gui.services.service_base import ServiceBase
+
+
+class VersionService(ServiceBase):
+    """Responsible for retrieving version information"""
+
+    def expose(self) -> None:
+        eel.expose(self.get_version)
+
+    def get_version(self) -> str:
+        return "0.0.1"

--- a/src/electionguard_gui/services/version_service.py
+++ b/src/electionguard_gui/services/version_service.py
@@ -1,3 +1,4 @@
+from os import path
 import eel
 from git import Repo
 from electionguard_gui.services.eel_log_service import EelLogService
@@ -16,8 +17,11 @@ class VersionService(ServiceBase):
         eel.expose(self.get_version)
 
     def get_version(self) -> str:
-        repo = Repo("./")
-        commit_hash = repo.git.rev_parse("HEAD")
-        short_hash = commit_hash[:6]
-        self._log.info(f"Version: {short_hash}")
-        return short_hash
+        if path.exists(".git"):
+            repo = Repo("./")
+            commit_hash = repo.git.rev_parse("HEAD")
+            short_hash = commit_hash[:6]
+            self._log.info(f"Version: {short_hash}")
+            return short_hash
+        else:
+            return "unknown"

--- a/src/electionguard_gui/web/components/shared/footer-component.js
+++ b/src/electionguard_gui/web/components/shared/footer-component.js
@@ -9,7 +9,7 @@ export default {
   },
   template: /*html*/ `
   <nav class="navbar fixed-bottom bg-light">
-    <div class="container">
+    <div class="container-fluid">
         <div class="col-12 pe-0 text-end text-secondary text-opacity-75" v-if="version">
           ElectionGuard version {{version}}
         </div>

--- a/src/electionguard_gui/web/components/shared/footer-component.js
+++ b/src/electionguard_gui/web/components/shared/footer-component.js
@@ -1,0 +1,19 @@
+export default {
+  data() {
+    return {
+      version: null,
+    };
+  },
+  async mounted() {
+    this.version = await eel.get_version()();
+  },
+  template: /*html*/ `
+  <nav class="navbar fixed-bottom bg-light">
+    <div class="container">
+        <div class="col-12 pe-0 text-end text-secondary text-opacity-75" v-if="version">
+          ElectionGuard version {{version}}
+        </div>
+    </div>
+  </nav>
+  `,
+};

--- a/src/electionguard_gui/web/components/shared/footer-component.js
+++ b/src/electionguard_gui/web/components/shared/footer-component.js
@@ -8,9 +8,9 @@ export default {
     this.version = await eel.get_version()();
   },
   template: /*html*/ `
-  <nav class="navbar fixed-bottom bg-light">
+  <nav class="navbar fixed-bottom bg-light" v-if="version">
     <div class="container-fluid">
-        <div class="col-12 pe-0 text-end text-secondary text-opacity-75" v-if="version">
+        <div class="col-12 pe-0 text-end text-secondary text-opacity-75">
           ElectionGuard version {{version}}
         </div>
     </div>

--- a/src/electionguard_gui/web/index.html
+++ b/src/electionguard_gui/web/index.html
@@ -20,10 +20,11 @@
 
     <div id="app">
       <navbar :user-id="userId"></navbar>
-      <div class="container mt-3">
+      <div class="container mt-3 mb-4">
         <Login @login="login" v-if="showLogin"></Login>
         <component :is="currentView" v-bind="currentViewProperties" />
       </div>
+      <eg-footer></eg-footer>
     </div>
 
     <script type="module">
@@ -32,6 +33,7 @@
       // components
       import Navbar from "./components/shared/navbar-component.js";
       import Login from "./components/shared/login-component.js";
+      import EgFooter from "./components/shared/footer-component.js";
 
       // services
       import AuthorizationService from "./services/authorization-service.js";
@@ -83,6 +85,7 @@
         components: {
           Navbar,
           Login,
+          EgFooter,
         },
       }).mount("#app");
     </script>


### PR DESCRIPTION
### Issue
Fixes #762

### Description
Shows the version info when you run via `git egui` (not via docker, although we could add that with very little effort)

### Testing
1. Run `git egui`

Expected, a git sha hash like this:

![image](https://user-images.githubusercontent.com/1769905/186959031-b6cddc3d-3777-44ce-a127-e561f9af5513.png)
