### PR TITLE
#742 - Fix Encryption Package Overwrite Bug

### DIFF
--- a/src/electionguard_gui/components/create_election_component.py
+++ b/src/electionguard_gui/components/create_election_component.py
@@ -103,7 +103,12 @@ class CreateElectionComponent(ComponentBase):
             self._output_setup_files_step.output(
                 election_inputs, build_election_results, temp_out_dir, None
             )
-            zip_file = path.join(get_data_dir(), "public_encryption_package")
+            zip_file = path.join(
+                get_data_dir(),
+                "encryption_packages",
+                key_ceremony_id,
+                "public_encryption_package",
+            )
             encryption_package_file = self._zip(temp_out_dir, zip_file)
             guardian_records = [
                 guardian.publish() for guardian in election_inputs.guardians


### PR DESCRIPTION
### Issue

Fixes #742 

### Description
This fixes the bug where a creating a second election internally overwrites the election package of any prior elections.

### Testing
1. Create key ceremony
2. Create election
3. Create a 2nd key ceremony
4. Create a 2nd election
5. Go to 1st election
6. Export 1st election's encryption page
7. Encrypt and upload ballots based the exported encryption package to the 1st election
8. Perform a decryption

Expected: this previously caused an infinite loop.  Now it does not.