### PR TITLE
During serialization don't convert unicode to ASCII

### DIFF
--- a/src/electionguard/serialize.py
+++ b/src/electionguard/serialize.py
@@ -84,7 +84,7 @@ def from_list_raw(type_: Type[_T], raw: Union[str, bytes]) -> List[_T]:
 def to_raw(data: Any) -> str:
     """Serialize data to raw json format."""
 
-    return json.dumps(data, default=pydantic_encoder)
+    return json.dumps(data, ensure_ascii=False, default=pydantic_encoder)
 
 
 def from_file_wrapper(type_: Type[_T], file: TextIOWrapper) -> _T:
@@ -139,7 +139,7 @@ def to_file(
         "w",
         encoding=BYTE_ENCODING,
     ) as outfile:
-        json.dump(data, outfile, default=pydantic_encoder)
+        json.dump(data, outfile, ensure_ascii=False, default=pydantic_encoder)
         return path
 
 


### PR DESCRIPTION
### Issue

Fixes #791 

### Description
During serialization unicode like `Raúl` will no longer be encoded as `Ra\u00fal` and will instead just be encoded as `Raúl`.

### Testing
1. Modify a manifest to put unicode in a candidate's name.  
2. Create an election in the GUI
3. Export an encryption package

Expected: the candidate's name should contain unicode